### PR TITLE
feat(kernel: memory): switch to a higher-half kernel

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,9 +1,0 @@
-# Connect to qemu's gdbserver
-target remote :1234
-
-# Change layout
-layout reg
-
-# Continue execution until entering the kernel
-break kernel_main
-continue

--- a/kernel/arch/i686/linker.ld
+++ b/kernel/arch/i686/linker.ld
@@ -4,33 +4,67 @@
  */
 ENTRY(_kernel_start)
 
+_kernel_physical_start = 0x00100000;
+_kernel_higher_half_offset =  0xC0000000;
+_kernel_virtual_start = (_kernel_physical_start + _kernel_higher_half_offset);
+
 SECTIONS
 {
+    /*
+     * Starting from #6 we now use a higher-half kernel.
+     *
+     * The load address of the kernel is different from the relocation address (AT).
+     * We run the code as if in higher-half, but is should in fact be loaded at the
+     * beginning of the RAM to be detected by the bootloader.
+     *
+     * We still need to run the piece of code that jumps to our main function,
+     * that is why we have 2 different sections for the code:
+     * * .text.startup: should be identically mapped (load address == relocation address)
+     * * .text: should be loaded as higher half
+     *
+     * The code inside the .text.startup section can be discarded once we jumped to our
+     * main C function, we shall never get back to it anyway.
+     *
+     * For more information, refer to: https://wiki.osdev.org/Higher_Half_x86_Bare_Bones
+     */
+
     /* We place our kernel at 1MiB, it's a conventional place for it to be here. */
-    . = 1M;
+    . = ALIGN(4K);
+    . = _kernel_physical_start;
+
+    /* Code needed to bootstrap our kernel, cannot be remmaped */
+    .startup ALIGN(4K) :
+    {
+        KEEP(*(.multiboot))
+        *(.text.startup)
+    }
+
+    /* Everything after this is relocated to the end of the address space (> 3GiB) and needs paging to be activated */
+
+    . = ALIGN(4K);
+    . += _kernel_higher_half_offset;
 
     _kernel_code_start = .;
 
-    .text BLOCK(4K) : ALIGN(4K)
+    .text ALIGN(4K) : AT (ADDR (.text) - _kernel_higher_half_offset)
     {
-        *(.multiboot)
         *(.text)
     }
 
     /* Read-only data */
-    .rodata BLOCK(4K) : ALIGN(4K)
+    .rodata ALIGN(4K) : AT (ADDR (.rodata) - _kernel_higher_half_offset)
     {
         *(.rodata)
     }
 
     /* Initialized data (RW) */
-    .data BLOCK(4K) : ALIGN(4K)
+    .data ALIGN(4K) : AT (ADDR (.data) - _kernel_higher_half_offset)
     {
         *(.data)
     }
 
     /* Uninitialized data and stack (RW) */
-    .bss BLOCK(4K) : ALIGN(4K)
+    .bss ALIGN(4K) : AT (ADDR (.bss) - _kernel_higher_half_offset)
     {
         *(COMMON)
         *(.bss)

--- a/kernel/arch/i686/linker.ld
+++ b/kernel/arch/i686/linker.ld
@@ -9,7 +9,7 @@ SECTIONS
     /* We place our kernel at 1MiB, it's a conventional place for it to be here. */
     . = 1M;
 
-    kernel_code_start_address = .;
+    _kernel_code_start = .;
 
     .text BLOCK(4K) : ALIGN(4K)
     {
@@ -23,7 +23,7 @@ SECTIONS
         *(.rodata)
     }
 
-    /* Initailized data (RW) */
+    /* Initialized data (RW) */
     .data BLOCK(4K) : ALIGN(4K)
     {
         *(.data)
@@ -36,5 +36,5 @@ SECTIONS
         *(.bss)
     }
 
-    kernel_code_end_address = .;
+    _kernel_code_end = .;
 }

--- a/kernel/arch/i686/memory/mmu.c
+++ b/kernel/arch/i686/memory/mmu.c
@@ -1,4 +1,5 @@
 #include <kernel/logger.h>
+#include <kernel/memory.h>
 #include <kernel/mmu.h>
 #include <kernel/pmm.h>
 

--- a/kernel/include/kernel/memory.h
+++ b/kernel/include/kernel/memory.h
@@ -25,11 +25,15 @@
 /// one. The following constants are used by the linker script and should be
 /// used by the functions that depend on them instead of hardcoding values.
 
-#define KERNEL_IS_HIGHER_HALF
+#define KERNEL_IS_HIGHER_HALF 1
 
-#define KERNEL_PHYSICAL_START 0x00100000
-#define KERNEL_VIRTUAL_START 0xC0000000
-#define KERNEL_MEMORY_OFFSET (KERNEL_VIRTUAL_START - KERNEL_PHYSICAL_START)
+// TODO: These values are duplicated inside the linkerscript
+//       We should maybe find a way to include this header before linking the
+//       kernel to avoid conflicts
+
+#define KERNEL_PHYSICAL_START 0x00100000UL
+#define KERNEL_HIGHER_HALF_OFFSET 0xC0000000UL
+#define KERNEL_VIRTUAL_START (KERNEL_PHYSICAL_START + KERNEL_HIGHER_HALF_OFFSET)
 
 #ifndef __ASSEMBLER__
 

--- a/kernel/include/kernel/memory.h
+++ b/kernel/include/kernel/memory.h
@@ -1,0 +1,54 @@
+/** @file memory.h
+ *
+ *  Constants related to the kernel's memory layout.
+ */
+
+#ifndef KERNEL_MEMORY_H
+#define KERNEL_MEMORY_H
+
+// NOTE: This maybe belong inside the arch directory ? (cf. #5)
+
+// The size of a single page
+#define PAGE_SIZE (4096)
+
+// 32-bit address bus -> 4GiB of addressable memory
+#define ADDRESS_SPACE_SIZE (0x100000000UL)
+#define ADDRESS_SPACE_END (ADDRESS_SPACE_SIZE - 1)
+
+/// Starting from #6, our kernel uses the higher-half design.
+///
+/// This means that the kernel code's virtual address differs from its physical
+/// one. The following constants are used by the linker script and should be
+/// used by the functions that depend on them instead of hardcoding values.
+
+#define KERNEL_IS_HIGHER_HALF
+
+#define KERNEL_PHYSICAL_START 0x00100000
+#define KERNEL_VIRTUAL_START 0xC0000000
+#define KERNEL_MEMORY_OFFSET (KERNEL_VIRTUAL_START - KERNEL_PHYSICAL_START)
+
+#ifndef __ASSEMBLER__
+
+#include <utils/types.h>
+
+/// @brief Address of the byte located just before the end of the kernel's code
+///
+/// Any byte written after this address **WILL** overwrite our kernel's
+/// executable binary.
+///
+/// @info this address is defined inside the kernel's linker scrpit.
+extern u32 _kernel_code_start;
+#define KERNEL_CODE_START ((u32)&_kernel_code_start)
+
+/// @brief Address of the byte located just after the end of the kernel's code
+///
+/// Any byte written after this address will not overwrite our kernel's
+/// executable binary.
+///
+/// @info this address is defined inside the kernel's linker scrpit.
+extern u32 _kernel_code_end;
+#define KERNEL_CODE_END ((u32)&_kernel_code_end)
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* KERNEL_MEMORY_H */

--- a/kernel/include/kernel/memory.h
+++ b/kernel/include/kernel/memory.h
@@ -6,6 +6,10 @@
 #ifndef KERNEL_MEMORY_H
 #define KERNEL_MEMORY_H
 
+#ifndef KERNEL_STACK_SIZE
+#define KERNEL_STACK_SIZE 0x4000
+#endif
+
 // NOTE: This maybe belong inside the arch directory ? (cf. #5)
 
 // The size of a single page

--- a/kernel/include/kernel/memory.h
+++ b/kernel/include/kernel/memory.h
@@ -35,7 +35,19 @@
 #define KERNEL_HIGHER_HALF_OFFSET 0xC0000000UL
 #define KERNEL_VIRTUAL_START (KERNEL_PHYSICAL_START + KERNEL_HIGHER_HALF_OFFSET)
 
-#ifndef __ASSEMBLER__
+#ifdef __ASSEMBLER__
+
+#define KERNEL_HIGHER_HALF_PHYSICAL(_virtual) \
+    ((_virtual)-KERNEL_HIGHER_HALF_OFFSET)
+#define KERNEL_HIGHER_HALF_VIRTUAL(_physical) \
+    ((_physical) + KERNEL_HIGHER_HALF_OFFSET)
+
+#else
+
+#define KERNEL_HIGHER_HALF_PHYSICAL(_virtual) \
+    ((u32)(_virtual)-KERNEL_HIGHER_HALF_OFFSET)
+#define KERNEL_HIGHER_HALF_VIRTUAL(_physical) \
+    ((u32)(_physical) + KERNEL_HIGHER_HALF_OFFSET)
 
 #include <utils/types.h>
 

--- a/kernel/include/kernel/pmm.h
+++ b/kernel/include/kernel/pmm.h
@@ -14,16 +14,11 @@
 #ifndef KERNEL_PMM_H
 #define KERNEL_PMM_H
 
+#include <kernel/memory.h>
+
 #include <multiboot.h>
 #include <stdbool.h>
 #include <utils/types.h>
-
-// The size of a single page
-#define PAGE_SIZE (4096)
-
-// 32-bit address bus -> 4GiB of addressable memory
-#define ADDRESS_SPACE_SIZE (0x100000000UL)
-#define ADDRESS_SPACE_END (ADDRESS_SPACE_SIZE - 1)
 
 // Error value returned by the PMM in case of errors
 #define PMM_INVALID_PAGEFRAME (0xFFFFFFFFUL)
@@ -38,24 +33,6 @@
 // This constant should ONLY be used as a compile-time known theoretical
 // reference value (e.g. the physical memory manager's bit map size).
 #define TOTAL_PAGEFRAMES_COUNT (ADDRESS_SPACE_SIZE / PAGE_SIZE)
-
-/// @brief Address of the byte located just after the end of the kernel's code
-///
-/// Any byte written after this address will not overwrite our kernel's
-/// executable binary.
-///
-/// @info this address is defined inside the kernel's linker scrpit.
-extern u32 kernel_code_end_address;
-#define KERNEL_CODE_END ((u32)&kernel_code_end_address)
-
-/// @brief Address of the byte located just before the end of the kernel's code
-///
-/// Any byte written after this address **WILL** overwrite our kernel's
-/// executable binary.
-///
-/// @info this address is defined inside the kernel's linker scrpit.
-extern u32 kernel_code_start_address;
-#define KERNEL_CODE_START ((u32)&kernel_code_start_address)
 
 /// \defgroup pmm_allocation_flags
 ///

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -1,7 +1,6 @@
 arch = target_machine.cpu()
 
 kernel_compile_flags = [
-  '-DSTACK_SIZE=16384',
   '-fomit-frame-pointer',
 ]
 

--- a/kernel/src/crt0.S
+++ b/kernel/src/crt0.S
@@ -31,6 +31,31 @@ stack_bottom:
 stack_top:
 
 /*
+ * Temporary paging structure used by the startup code to temporarily activate paging.
+
+ * This is needed as we use a higher-half kernel design, meaning the kernel's code
+ * has been virtually relocated into the higher-half of the address space by the linker.
+ *
+ * Refer to #6 for more info.
+ *
+ * WARNING: Each and every block of 4MiB inside the address space are mapped to the first 1024 pageframes.
+ *          This only works if the kernel is smaller than 3MiB in size.
+ */
+
+.section .data
+.align PAGE_SIZE
+startup_page_directory:
+    .rept 1024
+    .long (startup_page_table - 0xC0000000) + 1
+    .endr
+startup_page_table:
+    .set addr, 0
+    .rept 1024
+    .long addr | 3
+    .set addr, addr + 0x1000
+    .endr
+
+/*
  * The entry point of our kernel (as defined in our linker script).
  *
  * This is the function called by the bootloader after detection the
@@ -40,11 +65,30 @@ stack_top:
  * no paging, and complete control over the hardware. The wild wild west ...
  */
 
+ #define PHYSICAL_ADDR(_symbol) $(_symbol - 0xC0000000)
+
 .section .text.startup
 .global _kernel_start
 .type _kernel_start, @function
 
 _kernel_start:
+    // install temporary bootstrap paging structure
+    movl PHYSICAL_ADDR(startup_page_directory), %ecx
+    movl %ecx, %cr3
+    // activate paging
+    movl %cr0, %ecx
+    orl $0x80000000, %ecx
+    movl %ecx, %cr0
+    // jump to higher half
+    lea higher_half, %ecx
+    jmp *%ecx
+
+.size _kernel_start, . - _kernel_start
+
+.section .text
+higher_half:
+
+    // Starting from here we are running in higher-half !
 
     // Initialize stack pointer
     mov $stack_top, %esp
@@ -52,6 +96,7 @@ _kernel_start:
     // The bootloader stores information about our system (memory map, ...)
     // inside these registers. We push them onto the stack to be able to access them
     // as arguments of our main function.
+    addl $KERNEL_HIGHER_HALF_OFFSET, %ebx
     push %eax
     push %ebx
 
@@ -65,5 +110,4 @@ _kernel_exit_loop:
     hlt
     jmp _kernel_exit_loop
 
-// Set the size of the _kernel_start symbol for debugging purposes
-.size _kernel_start, . - _kernel_start
+.size higher_half, . - higher_half

--- a/kernel/src/crt0.S
+++ b/kernel/src/crt0.S
@@ -65,15 +65,13 @@ startup_page_table:
  * no paging, and complete control over the hardware. The wild wild west ...
  */
 
- #define PHYSICAL_ADDR(_symbol) $(_symbol - 0xC0000000)
-
 .section .text.startup
 .global _kernel_start
 .type _kernel_start, @function
 
 _kernel_start:
     // install temporary bootstrap paging structure
-    movl PHYSICAL_ADDR(startup_page_directory), %ecx
+    movl $KERNEL_HIGHER_HALF_PHYSICAL(startup_page_directory), %ecx
     movl %ecx, %cr3
     // activate paging
     movl %cr0, %ecx

--- a/kernel/src/crt0.S
+++ b/kernel/src/crt0.S
@@ -15,10 +15,6 @@
 .long MULTIBOOT_HEADER_FLAGS
 .long -(MULTIBOOT_HEADER_FLAGS + MULTIBOOT_HEADER_MAGIC)
 
-#ifndef STACK_SIZE
-#error You must define STACK_SIZE
-#endif
-
 /*
  * The stack, required by C functions and not defined by default.
  * Should be placed inside the stack pointer register (esp) inside
@@ -30,7 +26,7 @@
 .section .bss
 .align 16
 stack_bottom:
-    .skip STACK_SIZE
+    .skip KERNEL_STACK_SIZE
 stack_top:
 
 /*

--- a/kernel/src/crt0.S
+++ b/kernel/src/crt0.S
@@ -1,5 +1,6 @@
-#include <multiboot.h>
+#include <kernel/memory.h>
 
+#include <multiboot.h>
 
 /*
  * Define the multiboot_header, following the GNU multiboot specifications,
@@ -39,7 +40,7 @@ stack_top:
  * no paging, and complete control over the hardware. The wild wild west ...
  */
 
-.section .text
+.section .text.startup
 .global _kernel_start
 .type _kernel_start, @function
 

--- a/kernel/src/memory/pmm.c
+++ b/kernel/src/memory/pmm.c
@@ -38,13 +38,13 @@ typedef struct {
 
 static pmm_frame_allocator g_pmm_user_allocator = {
     .start = 0,
-    .end = (u32)&kernel_code_start_address,
+    .end = KERNEL_CODE_START,
     .first_available = PMM_INVALID_PAGEFRAME,
     .initialized = false,
 };
 
 static pmm_frame_allocator g_pmm_kernel_allocator = {
-    .start = (u32)&kernel_code_start_address,
+    .start = KERNEL_CODE_START,
     .end = ADDRESS_SPACE_END,
     .first_available = PMM_INVALID_PAGEFRAME,
     .initialized = false,

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Start a GDB session connected to our kernel.
+# You can also pass in symbols to set breakpoints on as arguments.
+#
+# example: ./debug.sh kernel_main mmu_init
+
+# Absolute path to this script
+SCRIPT=$(readlink -f "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+GITROOT="$SCRIPTDIR/.."
+
+if ! command -v gdb > /dev/null; then
+    echo "[ERROR] GDB not found in path" >&2
+    exit 127
+fi
+
+cd "$GITROOT" || exit
+
+BREAKPOINTS=()
+for symbol in "$@"; do
+    BREAKPOINTS+=("-ex" "break $symbol")
+done
+
+if [ ! -d "build" ]; then
+    echo "[INFO] build dir not found, setting up meson project"
+    meson setup build --cross-file "scripts/meson_cross.ini" --reconfigure -Dbuildtype=debug
+fi
+
+echo "[INFO] Starting a debugging session"
+ninja -C build qemu-server || exit
+gdb --symbol ./build/kernel/kernel.sym \
+    -iex "set pagination of" \
+    -iex "target remote localhost:1234" \
+    "${BREAKPOINTS[@]}" \
+    -ex "continue"
+
+echo "[INFO] Terminating debugging session"
+pkill qemu


### PR DESCRIPTION
## What ?

Virtually relocate our kernel's code into the higher-half of the address space (0xC0000000).

## Why ?

This will simplify the process of including our kernel's code into userland processes later on, and make it easier to link them against our kernel.

Please refer to the related issue (#6) for detailed information.

## Related issue

Resolves #6 