### PR TITLE
feat(kernel: fs): add virtual filesystem

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,3 +35,8 @@ IncludeCategories:
       Priority: 4
     - Regex: '.*'
       Priority: 5
+
+ForEachMacros:
+  - FOREACH_LLIST
+  - FOREACH_CHILDREN
+  - FOREACH_MULTIBOOT_MODULE

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ compile_commands.json
 
 docs/doxygen/doc
 
+initramfs.*
+
 # qemu
 *.iso
 *.qcow2

--- a/include/kernel/device.h
+++ b/include/kernel/device.h
@@ -1,0 +1,55 @@
+#pragma once
+
+/**
+ * @defgroup kernel_device Devices
+ * @ingroup kernel
+ *
+ * # Devices
+ *
+ * @{
+ */
+
+#include <kernel/types.h>
+
+#include <stddef.h>
+
+#include "kernel/error.h"
+
+/** @struct device
+ *  @brief Represents a device
+ *
+ * In the current implementation, as everything is stored in RAM, the device
+ * struct is simply a wrapper arround what could be considered a contiguous
+ * buffer in memory.
+ *
+ * In the future though, the device structure should become a common interface
+ * between devices of different types (e.g. ram and hard disks should share this
+ * API)
+ */
+typedef struct device {
+    u32 start;   ///< Start address of the device in memory
+    size_t size; ///< Size of the memory area for this device
+
+    /** @struct device_operations
+     *  @brief VTable of I/O operations for the device
+     */
+    struct device_operations {
+        error_t (*read)(const struct device *, char *buffer, size_t offset,
+                        size_t size);
+        error_t (*write)(const struct device *, size_t offset,
+                         const char *buffer, size_t size);
+    } operations;
+} dev_t;
+
+/** Create a new device
+ *
+ *  @warning This implementation only serves as a place holder for the actual
+ *           one in order to ease the migration once it is implemneted. This API
+ *           **WILL** change.
+ *
+ *  @param start The starting address of the device's memory range
+ *  @param size The size of teh device's memory range
+ */
+dev_t *device_new(u32 start, size_t size);
+
+/** @} */

--- a/include/kernel/error.h
+++ b/include/kernel/error.h
@@ -27,9 +27,11 @@
  */
 typedef enum error {
     E_SUCCESS,              ///< No error
+    E_NOENT = 2,            ///< No such file or directory
     E_NOMEM = 12,           ///< Out of memory
     E_INVAL = 22,           ///< Invalid argument
     E_NOT_IMPLEMENTED = 38, ///< Function not implemented
+    E_NOT_SUPPORTED = 95,   ///< Operation not supported
     E_TOTAL_COUNT, ///< Total number of error codes, only used as a reference
 } error_t;
 

--- a/include/kernel/error.h
+++ b/include/kernel/error.h
@@ -38,7 +38,7 @@ typedef enum error {
 /** Construct a pointer containing info about an error */
 static ALWAYS_INLINE void *PTR_ERR(error_t err)
 {
-    return (void *)-err;
+    return (void *)((native_t)-err);
 }
 
 /** Extract the error value contained inside a pointer  */

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -41,4 +41,9 @@ typedef native_t vaddr_t;
 typedef u32 pid_t;
 typedef u64 timestamp_t;
 
+/** Comparison function over two generic objects
+ *  @return 0 if both are equal, -1 if left is inferior, +1 if it is superior
+ */
+typedef int (*compare_t)(const void *left, const void *right);
+
 #endif /* KERNEL_TYPES_H */

--- a/include/kernel/types.h
+++ b/include/kernel/types.h
@@ -29,6 +29,7 @@ typedef long int ssize_t;
 #ifdef ARCH_IS_32_BITS
 typedef u32 native_t;
 #elif defined(ARCH_IS_64_BITS)
+typedef u64 native_t;
 #else
 #error Unsuported architecture
 #endif

--- a/include/kernel/vfs.h
+++ b/include/kernel/vfs.h
@@ -48,6 +48,8 @@
 typedef struct vfs vfs_t;
 typedef struct vnode vnode_t;
 
+typedef enum vnode_type vnode_type;
+
 /** @defgroup fs_vfs_vfs Virtual filesystem
  *  @{
  */
@@ -119,6 +121,23 @@ error_t vfs_unmount(const char *path);
  */
 vnode_t *vfs_find_by_path(const char *path);
 
+/** Create a new file at the given path
+ *
+ *  @param path The path of the new child
+ *  @param type The type of the new file
+ *
+ *  @return filesystem specific errors, or:
+ *      * E_NOENT - Path is invalid
+ *      * E_EXIST - File already exists
+ */
+error_t vfs_create_at(const char *path, vnode_type type);
+
+/** Remove the file located at the given path
+ *
+ *  @return E_NOENT if the file does not exist
+ */
+error_t vfs_remove_at(const char *path);
+
 /** @} */
 
 /** @defgroup fs_vfs_vnode Virtual nodes
@@ -153,6 +172,9 @@ typedef struct vnode_operations {
      *  @returns E_INVAL - the parent vnode cannot have children (e.g. a file)
      */
     error_t (*create)(vnode_t *node, const char *name, vnode_type);
+
+    /** Remove a child from a directory */
+    error_t (*remove)(vnode_t *node, const char *child);
 
     /** Called by the VFS driver before deleting a vnode (optional).
      *  This is responsible for freeing/updating any necessary internal

--- a/include/kernel/vfs.h
+++ b/include/kernel/vfs.h
@@ -1,0 +1,225 @@
+#pragma once
+
+/**
+ * @file kernel/vfs.h
+ *
+ * @defgroup kernel_fs Filesystem
+ * @ingroup kernel
+ *
+ * @defgroup kernel_vfs VFS
+ * @ingroup kernel_fs
+ * @brief Virtual File System
+ *
+ * # Virtual Filesystem
+ *
+ * The virtual is an abstraction over filesystems used to separate the high
+ * level interface from the low level fs-dependent implementation.
+ * It also allows for computing a path which spans over multiple different
+ * imbricked filesystems, effectively viewing it as a single big filesystem from
+ * the user's POV.
+ *
+ * ## Design
+ *
+ * The VFS splits each mounted filesystem into 2 parts:
+ * * The virtual filesystem: The filesystem as a whole
+ * * Virtual nodes: The individual components (files, dirs, ...) that make up
+ *                  this filesystem
+ *
+ * The VFS driver keeps track of all the present virtual filesystem, and
+ * addresses them in order to find a requested path.
+ * When "opening" a file, we instead ask the corresponding VFS to create the
+ * VNODE which corresponds to this file, and interact with it instead. All the
+ * filesystem dependant logic is hidden from the VFS driver.
+ *
+ * @see http://www.cs.fsu.edu/~awang/courses/cop5611_s2024/vnode.pdf
+ *
+ * @{
+ */
+
+#include <kernel/device.h>
+#include <kernel/error.h>
+#include <kernel/types.h>
+
+#include <lib/path.h>
+#include <libalgo/linked_list.h>
+#include <utils/compiler.h>
+#include <utils/stringify.h>
+
+typedef struct vfs vfs_t;
+typedef struct vnode vnode_t;
+
+/** @defgroup fs_vfs_vfs Virtual filesystem
+ *  @{
+ */
+
+/** @struct vfs_operations
+ *  @brief Vector Table for operations on a filesystems
+ */
+typedef struct vfs_operations {
+    /** Retreive the root of the filesystem */
+    vnode_t *(*root)(vfs_t *);
+    /** Free internal structures and vnodes.
+     *  This function is called by the driver before unmounting the filesystem.
+     */
+    void (*delete)(vfs_t *);
+} vfs_ops_t;
+
+/**
+ * @struct vfs
+ * @brief represents a single virtual filesystem
+ */
+typedef struct vfs {
+    node_t this;
+    dev_t *dev;            ///< Device used by this filesystem
+    vfs_ops_t *operations; ///< @ref vfs_operations
+    vnode_t *node;         ///< vnode on which this FS is mounted
+    void *pdata;           ///< Private FS dependent data
+} vfs_t;
+
+/** Mount a filesystem of the given type at a given path.
+ *
+ * @param path Where the fs should be mounted (must be an existing
+ *                   directory)
+ * @param fs_type The name of the filesystem to mount
+ * @param device The device where the filesystem is stored
+ *
+ * @return
+ *          * E_INVAL - the filesystem does not exist
+ *          * E_INVAL - the path does not lead to a directory
+ *          * E_INVAL - another filesystem is mounted at the requested path
+ *          * E_NOENT - the path is invalid
+ */
+error_t vfs_mount(const char *path, const char *fs_type, dev_t *);
+
+/** Mount a filesystem at the root of the VFS.
+ *
+ *  @param fs_type The type of the filesystem
+ *  @param device The device where the filesystem is stored
+ *
+ *  @return
+ *          * E_INVAL - there already is a root for the VFS
+ *          * E_INVAL - the filesystem does not exist
+ */
+error_t vfs_mount_root(const char *fs_type, dev_t *);
+
+/** Unmount the filesystem present at the given path.
+ *
+ * @return
+ *      * E_INVAL - No file system mounted on the given path
+ */
+error_t vfs_unmount(const char *path);
+
+/** Retreive the vnode corresponding to a path
+ *
+ *  @warning The vnode returned by this function **must** be released using
+ *           \ref vfs_vnode_release once done with it
+ *
+ *  @return The vnode, or a pointer containing the error number:
+ *      * E_NOENT - Path does not exist
+ */
+vnode_t *vfs_find_by_path(const char *path);
+
+/** @} */
+
+/** @defgroup fs_vfs_vnode Virtual nodes
+ *  @{
+ */
+
+/** @enum vnode_type
+ *  @brief The different existing types of vnodes
+ */
+typedef enum vnode_type {
+    VNODE_FIFO = 0x1000,
+    VNODE_CHARDEVICE = 0x2000,
+    VNODE_DIRECTORY = 0x4000, ///< Regular directory
+    VNODE_BLOCKDEVICE = 0x6000,
+    VNODE_FILE = 0x8000,    ///< Regular file
+    VNODE_SYMLINK = 0xA000, ///< Symbolic link
+    VNODE_SOCKET = 0xC000,
+} vnode_type;
+
+/** @struct vnode_operations
+ *  @brief Vector table for operations performed on a single virtual node
+ */
+typedef struct vnode_operations {
+
+    /** Find a child node (by name) inside a directory node.
+     *  @warning The node returned by this function MUST be released afterwards
+     *           using \ref vfs_vnode_release (subject to change in the future).
+     */
+    vnode_t *(*lookup)(vnode_t *, const path_segment_t *);
+
+    /** Add a new child to the vnode.
+     *  @returns E_INVAL - the parent vnode cannot have children (e.g. a file)
+     */
+    error_t (*create)(vnode_t *node, const char *name, vnode_type);
+
+    /** Called by the VFS driver before deleting a vnode (optional).
+     *  This is responsible for freeing/updating any necessary internal
+     *  structures before deleting a vnode.
+     */
+    void (*release)(vnode_t *node);
+
+} vnode_ops_t;
+
+/** @struct vnode
+ *  @brief represents a single virtual node
+ */
+struct vnode {
+    vfs_t *fs;               ///< Filesystem to which this node belong
+    vnode_type type;         ///< Type of the node
+    u16 refcount;            ///< Number of references hold to that node
+    vnode_ops_t *operations; ///< @ref vnode_operations
+    void *pdata;             ///< Private node data
+};
+
+/** Increment the refcount of a vnode
+ *
+ * Similarily to any other synchronization mechanism, you must call
+ * \ref vfs_vnode_release once you are done using this node
+ *
+ * @param vnode The referenced vnode
+ * @param[out] new Set to true if a new vnode was created (optional)
+ *
+ * @return The original vnode, or a newly allocated one if NULL
+ */
+vnode_t *vfs_vnode_acquire(vnode_t *, bool *);
+
+/** Decrease the refcount of a vnode
+ *
+ * @warning The vnode is free'd if the new refcount is 0
+ *
+ * @return The original vnode, NULL if the new refcount is 0
+ */
+vnode_t *vfs_vnode_release(vnode_t *);
+
+/** @} */
+
+/** @struct vfs_fs
+ *  @brief Represents a file system format
+ *
+ *  This structure is used by the VFS driver to mount the filesystem.
+ */
+typedef ALIGNED(ARCH_WORD_SIZE) struct vfs_fs {
+    const char *const name; ///< Name of the filesystem
+    vfs_t *(*new)(dev_t *); ///< Create a new instance of this filesystem using
+                            ///< the given device
+} vfs_fs_t;
+
+/** Declare a new available filesystem.
+ *
+ * A file system **needs** to be declared using this macro for the VFS driver
+ * to be able to mount it using \c vfs_mount.
+ *
+ * @param fs_name The name of the filesystem
+ * @param fw_new The function used to create a new instance of this filesystem
+ */
+#define DECLARE_FILESYSTEM(fs_name, fs_new)      \
+    SECTION(".data.vfs.filesystems")             \
+    MAYBE_UNUSED                                 \
+    static vfs_fs_t fs_name##_fs_declaration = { \
+        .name = stringify(fs_name),              \
+        .new = fs_new,                           \
+    }
+
+/** @} */

--- a/include/kernel/vfs.h
+++ b/include/kernel/vfs.h
@@ -171,6 +171,7 @@ struct vnode {
     u16 refcount;            ///< Number of references hold to that node
     vnode_ops_t *operations; ///< @ref vnode_operations
     void *pdata;             ///< Private node data
+    vfs_t *mounted_here;     ///< Potential filesystem mounted over this node
 };
 
 /** Increment the refcount of a vnode

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -259,6 +259,12 @@ struct multiboot_apm_info {
     multiboot_uint16_t dseg_len;
 };
 
+#define FOREACH_MULTIBOOT_MODULE(_iter, _mbt)                            \
+    for (multiboot_module_t *_iter = (void *)(_mbt)->mods_addr;          \
+         _iter <                                                         \
+         &((multiboot_module_t *)(_mbt)->mods_addr)[(_mbt)->mods_count]; \
+         ++_iter)
+
 #endif /* ! ASM_FILE */
 
 #endif /* ! MULTIBOOT_HEADER */

--- a/include/utils/compiler.h
+++ b/include/utils/compiler.h
@@ -27,6 +27,7 @@
 #define NO_DISCARD __attribute__((warn_unused_result))
 #define MAYBE_UNUSED __attribute__((unused))
 #define ALIAS(_function) __attribute__((alias(_function)))
+#define ALIGNED(_alignment) __attribute__((aligned(_alignment)))
 
 /** Raises a compile time eror if \c _x is 0
  *  @return \c _x so that it can be used as a compile time known value

--- a/kernel/arch/i686/devices/timer.c
+++ b/kernel/arch/i686/devices/timer.c
@@ -108,8 +108,7 @@ u64 timer_gettick(void)
     return timer_ticks_counter;
 }
 
-static int process_cmp_wakeup(const node_t *current_node,
-                              const node_t *cmp_node)
+static int process_cmp_wakeup(const void *current_node, const void *cmp_node)
 {
     const process_t *current = container_of(current_node, process_t, this);
     const process_t *cmp = container_of(cmp_node, process_t, this);

--- a/kernel/fs/tar.c
+++ b/kernel/fs/tar.c
@@ -282,10 +282,19 @@ static error_t tar_vnode_create(vnode_t *vnode, const char *name,
     return E_NOT_SUPPORTED;
 }
 
+static error_t tar_vnode_remove(vnode_t *vnode, const char *name)
+{
+    UNUSED(vnode);
+    UNUSED(name);
+
+    return E_NOT_SUPPORTED;
+}
+
 static vnode_ops_t tar_vnode_ops = {
     .lookup = tar_vnode_lookup,
     .release = tar_vnode_release,
     .create = tar_vnode_create,
+    .remove = tar_vnode_remove,
 };
 
 static vfs_ops_t tar_vfs_ops = {

--- a/kernel/fs/tar.c
+++ b/kernel/fs/tar.c
@@ -1,0 +1,312 @@
+/**
+ * @defgroup vfs_tar TAR
+ * @ingroup kernel_fs
+ *
+ * @brief Tape ARchive format.
+ *
+ * # Tape ARchive format.
+ *
+ * It is a common general-purpose archive format, with tools to generate
+ * such archives available on every OS.
+ *
+ * @note As an archive format, the TAR filesystem is read-only by design.
+ *
+ * @see https://wiki.osdev.org/Tar
+ *
+ * @{
+ */
+#include <kernel/error.h>
+#include <kernel/kmalloc.h>
+#include <kernel/logger.h>
+#include <kernel/vfs.h>
+
+#include <lib/path.h>
+#include <libalgo/tree.h>
+#include <utils/compiler.h>
+#include <utils/container_of.h>
+#include <utils/macro.h>
+#include <utils/math.h>
+
+#include <stddef.h>
+#include <string.h>
+
+static vfs_ops_t tar_vfs_ops;
+static vnode_ops_t tar_vnode_ops;
+
+/** Pathname length inside a TAR format is limited to 99 characters (size
+ *  includes the NULL terminating byte)
+ */
+#define TAR_FILENAME_SIZE 100
+
+/** Each file gets a header that is padded up to 512 bytes (and is aligned on a
+ *  512 bytes boundary)
+ */
+#define TAR_HEADER_SIZE 512
+
+/** @struct tar_header
+ *  @brief Header located at the beginning of each file in the archive.
+ */
+typedef struct tar_header {
+    char filename[TAR_FILENAME_SIZE]; ///< Full path of the file
+    char mode[8];                     ///< Permissions
+    char uid[8];                      ///< Owner's numeric ID
+    char gid[8];                      ///< Group's numeric ID
+    char size[12];                    ///< Size of the file (excluding header)
+    char mtime[12];                   ///< Last modification time
+    char chksum[8];                   ///< Checksum
+
+    /** @enum tar_typeflag
+     *  @brief Different available types for a file inside a TAR archive
+     */
+    enum tar_typeflag {
+        TAR_TYPE_FILE = '0',
+        TAR_TYPE_HARDLINK = '1',
+        TAR_TYPE_SYMLINK = '2',
+        TAR_TYPE_CHARDEV = '3',
+        TAR_TYPE_BLOCKDEV = '4',
+        TAR_TYPE_DIRECTORY = '5',
+        TAR_TYPE_FIFO = '6',
+    } type; ///< The type of this file
+
+} hdr_t ALIGNED(TAR_HEADER_SIZE);
+
+/** @struct tar_filesystem
+ *  @brief Filesystem dependant data for a TAR archive
+ *
+ * This is the data that should go inside the `pdata` field of the containing
+ * \ref vfs_fs struct.
+ */
+typedef struct tar_filesystem {
+    tree_t root; ///< Root of this TAR archive's file tree.
+                 ///  This tree contains nodes of type \ref tar_node
+} tar_t;
+
+/** @struct tar_node
+ *  @brief Represents a file (or dir, etc ...) inside a TAR archive's file tree
+ */
+typedef struct tar_node {
+    tree_node_t this; ///< This file's intrusive node used by the tree
+    const char *name; ///< The name of this file
+    hdr_t *header;    ///< The TAR header corresponding to this file
+    vnode_t *vnode;   ///< The vnode corresponding to this file (if referenced)
+} tar_node_t;
+
+static vnode_t *tar_get_vnode(tar_node_t *node, vfs_t *fs);
+
+/*  Read a number contained inside a TAR header's field.
+ *  Numbers inside a TAR header are written in octal using ascii characters
+ *
+ *  @param field The ascii representation
+ *  @param len The number of bytes inside the field
+ */
+static size_t tar_read_number(const char *field, size_t len)
+{
+    size_t count = 0;
+    for (size_t i = 0; i < len; ++i) {
+        count *= 8;
+        count += field[i] - '0';
+    }
+
+    return count;
+}
+
+static tar_node_t *tar_create_node(const path_segment_t *segment, hdr_t *header)
+{
+    tar_node_t *new = kmalloc(sizeof(tar_node_t), KMALLOC_KERNEL);
+    if (new == NULL) {
+        log_err("tarfs", "Failed to allocate memory for a new node (%s)",
+                segment->start);
+        return PTR_ERR(E_NOMEM);
+    }
+
+    size_t name_len = path_segment_length(segment);
+    char *name = kmalloc(name_len + 1, KMALLOC_KERNEL);
+    if (name == NULL) {
+        kfree(new);
+        log_err("tarfs", "Failed to allocate memory for a new node (%s)",
+                segment->start);
+        return PTR_ERR(E_NOMEM);
+    }
+
+    strncpy(name, segment->start, name_len);
+    name[name_len] = '\0';
+    new->name = name;
+
+    // The parent directory are not necessarily added to the tar archive
+    // e.g. tar cvf initramfs.tar initramfs/bin/init initramfs/init
+    //   => initramfs is not present in the archive
+    new->header = path_segment_is_last(segment) ? header : NULL;
+
+    return new;
+}
+
+/* Check whether a tar node's name corresponds to a path segment */
+static int tar_node_is(const void *this, const void *segment)
+{
+    const path_segment_t *name = segment;
+    tar_node_t *node = container_of(this, tar_node_t, this);
+
+    return strncmp(node->name, name->start, path_segment_length(name));
+}
+
+/* Initialize the file tree of the TAR archive contained inside the device */
+static tree_t tar_init_tree(dev_t *dev)
+{
+    tar_node_t *tar_root = kcalloc(1, sizeof(tar_node_t), KMALLOC_KERNEL);
+    if (IS_ERR(tar_root))
+        return (tree_t)tar_root;
+
+    tar_root->header->type = TAR_TYPE_DIRECTORY;
+
+    // TODO: Read header from device
+    tree_t root = &tar_root->this;
+    for (hdr_t *header = (void *)dev->start; header->filename[0] != '\0';) {
+
+        path_t path = NEW_DYNAMIC_PATH(header->filename);
+        tree_node_t *current = root;
+
+        if (path.len >= TAR_FILENAME_SIZE)
+            continue;
+
+        DO_FOREACH_SEGMENT(segment, &path, {
+            tree_node_t *node = tree_find_child(current, tar_node_is, &segment);
+            if (!node) {
+                tar_node_t *new = tar_create_node(&segment, header);
+                // TODO: delete the whole tree
+                if (IS_ERR(new))
+                    break;
+                tree_add_child(current, &new->this);
+                node = &new->this;
+            }
+            current = node;
+        });
+
+        size_t size = tar_read_number(header->size, 11);
+        header = ((void *)header) + TAR_HEADER_SIZE + size;
+        header = (void *)align_up((uint32_t)header, TAR_HEADER_SIZE);
+    }
+
+    return root;
+}
+
+static vnode_t *tar_vnode_lookup(vnode_t *node, const path_segment_t *child)
+{
+    if (node->type == VNODE_FILE)
+        return PTR_ERR(E_NOT_SUPPORTED);
+    if (node->type != VNODE_DIRECTORY)
+        return PTR_ERR(E_NOT_IMPLEMENTED);
+
+    tar_node_t *tar_node = node->pdata;
+    tree_node_t *tar_child =
+        tree_find_child(&tar_node->this, tar_node_is, child);
+
+    if (tar_child == NULL)
+        return PTR_ERR(E_NOENT);
+
+    return tar_get_vnode(container_of(tar_child, tar_node_t, this), node->fs);
+}
+
+static void tar_vnode_release(vnode_t *vnode)
+{
+    tar_node_t *node = vnode->pdata;
+    node->vnode = NULL;
+}
+
+static vnode_t *tar_vfs_root(vfs_t *fs)
+{
+    tar_t *tar = fs->pdata;
+    tar_node_t *root = container_of(tar->root, tar_node_t, this);
+
+    return tar_get_vnode(root, fs);
+}
+
+static vnode_t *tar_get_vnode(tar_node_t *node, vfs_t *fs)
+{
+    bool new;
+    node->vnode = vfs_vnode_acquire(node->vnode, &new);
+
+    if (new) {
+        node->vnode->fs = fs;
+        node->vnode->operations = &tar_vnode_ops;
+        node->vnode->pdata = node;
+
+        switch (node->header->type) {
+        case TAR_TYPE_FILE:
+            node->vnode->type = VNODE_FILE;
+            break;
+        case TAR_TYPE_HARDLINK:
+        case TAR_TYPE_SYMLINK:
+            node->vnode->type = VNODE_SYMLINK;
+            break;
+        case TAR_TYPE_CHARDEV:
+            node->vnode->type = VNODE_CHARDEVICE;
+            break;
+        case TAR_TYPE_BLOCKDEV:
+            node->vnode->type = VNODE_BLOCKDEVICE;
+            break;
+        case TAR_TYPE_DIRECTORY:
+            node->vnode->type = VNODE_DIRECTORY;
+            break;
+        case TAR_TYPE_FIFO:
+            node->vnode->type = VNODE_FIFO;
+            break;
+        }
+    }
+
+    return node->vnode;
+}
+
+static error_t tar_vnode_create(vnode_t *vnode, const char *name,
+                                vnode_type type)
+{
+    UNUSED(vnode);
+    UNUSED(name);
+    UNUSED(type);
+
+    return E_NOT_SUPPORTED;
+}
+
+static vnode_ops_t tar_vnode_ops = {
+    .lookup = tar_vnode_lookup,
+    .release = tar_vnode_release,
+    .create = tar_vnode_create,
+};
+
+static vfs_ops_t tar_vfs_ops = {
+    .root = tar_vfs_root,
+};
+
+vfs_t *tar_new(dev_t *dev)
+{
+    log_info("tarfs", "mounting from [" LOG_FMT_32 ":" LOG_FMT_32 "]",
+             dev->start, dev->start + dev->size);
+
+    vfs_t *vfs = kcalloc(1, sizeof(vfs_t), KMALLOC_KERNEL);
+    if (vfs == NULL)
+        return PTR_ERR(E_NOMEM);
+
+    vfs->dev = dev;
+    vfs->operations = &tar_vfs_ops;
+
+    tree_t tree = tar_init_tree(dev);
+    if (IS_ERR(tree)) {
+        kfree(vfs);
+        return (vfs_t *)tree;
+    }
+
+    tar_t *tar_fs = kmalloc(sizeof(*tar_fs), KMALLOC_KERNEL);
+    if (tar_fs == NULL) {
+        kfree(vfs);
+        kfree(tree);
+        return PTR_ERR(E_NOMEM);
+    }
+
+    tar_fs->root = tree;
+    vfs->pdata = tar_fs;
+
+    return vfs;
+}
+
+DECLARE_FILESYSTEM(tarfs, tar_new);
+
+/** @} */

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -38,12 +38,8 @@ static vfs_t *vfs_root_fs()
     return container_of(llist_head(vfs_mountpoints), vfs_t, this);
 }
 
-error_t vfs_mount_root(const char *fs_type, dev_t *dev)
+static error_t vfs_mount_at(vnode_t *vnode, const char *fs_type, dev_t *dev)
 {
-    // Mounting a new root is not supported for the time being
-    if (!llist_is_empty(vfs_mountpoints))
-        return E_INVAL;
-
     const vfs_fs_t *fs = vfs_find_fs(fs_type);
     if (fs == NULL)
         return E_INVAL;
@@ -52,10 +48,63 @@ error_t vfs_mount_root(const char *fs_type, dev_t *dev)
     if (IS_ERR(new))
         return ERR_FROM_PTR(new);
 
-    // root fs points to no existing vnode
-    new->node = NULL;
+    new->node = vnode;
+    if (vnode)
+        vnode->mounted_here = new;
 
-    llist_add(&vfs_mountpoints, &new->this);
+    llist_add_tail(&vfs_mountpoints, &new->this);
+    return E_SUCCESS;
+}
+
+error_t vfs_mount_root(const char *fs_type, dev_t *dev)
+{
+    // Mounting a new root is not supported for the time being
+    if (!llist_is_empty(vfs_mountpoints))
+        return E_INVAL;
+
+    return vfs_mount_at(NULL, fs_type, dev);
+}
+
+error_t vfs_mount(const char *mount_path, const char *fs_type, dev_t *dev)
+{
+    vnode_t *mountpoint = vfs_find_by_path(mount_path);
+    if (IS_ERR(mountpoint))
+        return ERR_FROM_PTR(mountpoint);
+
+    if (mountpoint->mounted_here != NULL ||
+        mountpoint->type != VNODE_DIRECTORY) {
+        vfs_vnode_release(mountpoint);
+        return E_INVAL;
+    }
+
+    error_t err = vfs_mount_at(mountpoint, fs_type, dev);
+    if (err != E_SUCCESS) {
+        vfs_vnode_release(mountpoint);
+        return err;
+    }
+
+    return E_SUCCESS;
+}
+
+error_t vfs_unmount(const char *path)
+{
+    vnode_t *vnode = vfs_find_by_path(path);
+    if (IS_ERR(vnode))
+        return ERR_FROM_PTR(vnode);
+
+    if (vnode->mounted_here == NULL) {
+        vfs_vnode_release(vnode);
+        return E_INVAL;
+    }
+
+    llist_remove(&vfs_mountpoints, &vnode->mounted_here->this);
+    vnode->mounted_here->operations->delete (vnode->mounted_here);
+    // The mounted FS kept a reference to the vnode it was mounted on
+    vfs_vnode_release(vnode);
+
+    // Release the reference acquired by vfs_find_by_path
+    vfs_vnode_release(vnode);
+
     return E_SUCCESS;
 }
 
@@ -63,19 +112,31 @@ vnode_t *vfs_find_by_path(const char *raw_path)
 {
     path_t path = NEW_DYNAMIC_PATH(raw_path);
 
-    vfs_t *root_fs = vfs_root_fs();
-    if (root_fs == NULL)
+    vfs_t *fs = vfs_root_fs();
+    if (fs == NULL)
         return PTR_ERR(E_NOENT);
 
-    vnode_t *current = root_fs->operations->root(root_fs);
+    vnode_t *current = fs->operations->root(fs);
     DO_FOREACH_SEGMENT(segment, &path, {
-        vnode_t *old = current;
+        vnode_t *old;
+
+        // If a filesystem is mounted on the current node, continue the search
+        // inside the mounted filesystem.
+        if (current->mounted_here) {
+            old = current;
+            fs = current->mounted_here;
+            current = fs->operations->root(fs);
+            vfs_vnode_release(old);
+        }
+
+        old = current;
         current = current->operations->lookup(current, &segment);
         // NOTE: vfs_vnode_acquire is called inside the `lookup` function in
         //       order to return the new vnoden this is why we must release
         //       this vnode. This looks a bit weird, or 'hidden', and should
         //       maybe be refactored.
         vfs_vnode_release(old);
+
         if (IS_ERR(current))
             break;
     });

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -1,0 +1,115 @@
+#include <kernel/error.h>
+#include <kernel/kmalloc.h>
+#include <kernel/logger.h>
+#include <kernel/vfs.h>
+
+#include <utils/container_of.h>
+
+#include <string.h>
+
+DECLARE_LLIST(vfs_mountpoints);
+
+// Defined inside our linkerscript
+// These symbols are placed around the '.data.vfs.filesystems' section
+extern u32 _kernel_filesystems_start;
+extern u32 _kernel_filesystems_end;
+
+static const vfs_fs_t *kernel_filesystems_start =
+    (const vfs_fs_t *)&_kernel_filesystems_start;
+
+static const vfs_fs_t *kernel_filesystems_end =
+    (const vfs_fs_t *)&_kernel_filesystems_end;
+
+static const vfs_fs_t *vfs_find_fs(const char *fs_type)
+{
+    for (const vfs_fs_t *fs = kernel_filesystems_start;
+         fs < kernel_filesystems_end; ++fs) {
+        if (!strcmp(fs->name, fs_type))
+            return fs;
+    }
+
+    return NULL;
+}
+
+static vfs_t *vfs_root_fs()
+{
+    if (llist_is_empty(vfs_mountpoints))
+        return NULL;
+    return container_of(llist_head(vfs_mountpoints), vfs_t, this);
+}
+
+error_t vfs_mount_root(const char *fs_type, dev_t *dev)
+{
+    // Mounting a new root is not supported for the time being
+    if (!llist_is_empty(vfs_mountpoints))
+        return E_INVAL;
+
+    const vfs_fs_t *fs = vfs_find_fs(fs_type);
+    if (fs == NULL)
+        return E_INVAL;
+
+    vfs_t *new = fs->new (dev);
+    if (IS_ERR(new))
+        return ERR_FROM_PTR(new);
+
+    // root fs points to no existing vnode
+    new->node = NULL;
+
+    llist_add(&vfs_mountpoints, &new->this);
+    return E_SUCCESS;
+}
+
+vnode_t *vfs_find_by_path(const char *raw_path)
+{
+    path_t path = NEW_DYNAMIC_PATH(raw_path);
+
+    vfs_t *root_fs = vfs_root_fs();
+    if (root_fs == NULL)
+        return PTR_ERR(E_NOENT);
+
+    vnode_t *current = root_fs->operations->root(root_fs);
+    DO_FOREACH_SEGMENT(segment, &path, {
+        vnode_t *old = current;
+        current = current->operations->lookup(current, &segment);
+        // NOTE: vfs_vnode_acquire is called inside the `lookup` function in
+        //       order to return the new vnoden this is why we must release
+        //       this vnode. This looks a bit weird, or 'hidden', and should
+        //       maybe be refactored.
+        vfs_vnode_release(old);
+        if (IS_ERR(current))
+            break;
+    });
+
+    return current;
+}
+
+vnode_t *vfs_vnode_acquire(vnode_t *node, bool *new)
+{
+    if (node == NULL) {
+        node = kcalloc(1, sizeof(vnode_t), KMALLOC_KERNEL);
+        if (node == NULL)
+            return PTR_ERR(E_NOMEM);
+        if (new)
+            *new = true;
+    } else {
+        if (new)
+            *new = false;
+    }
+
+    node->refcount += 1;
+
+    return node;
+}
+
+vnode_t *vfs_vnode_release(vnode_t *node)
+{
+    if (node->refcount <= 1) {
+        if (node->operations->release)
+            node->operations->release(node);
+        kfree(node);
+        return NULL;
+    }
+
+    node->refcount -= 1;
+    return node;
+}

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -61,6 +61,12 @@ SECTIONS
     .data ALIGN(4K) : AT (ADDR (.data) - _kernel_higher_half_offset)
     {
         *(.data)
+
+        /* Used to iterate over the different available filesystems */
+        _kernel_filesystems_start = .;
+        *(.data.vfs.filesystems)
+        . = ALIGN(4);
+        _kernel_filesystems_end = .;
     }
 
     /* Uninitialized data and stack (RW) */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -199,6 +199,8 @@ void kernel_main(struct multiboot_info *mbt, unsigned int magic)
                         err_to_str(ret));
             if ((ret = vfs_unmount("/bin") != E_INVAL))
                 log_err("rootfs", "Should not be able to unmount twice");
+            log_dbg("rootfs", "creating file: %s",
+                    err_to_str(vfs_create_at("/usr/bin/gcc///", VNODE_FILE)));
         }
     }
 

--- a/kernel/memory/kmalloc.c
+++ b/kernel/memory/kmalloc.c
@@ -64,8 +64,7 @@ static_assert(sizeof(bucket_t) <= KMALLOC_ALIGNMENT,
 /** Find a bucket containing with at least one free block of the given size */
 static bucket_t *bucket_find(llist_t buckets, size_t size, const u16 flags)
 {
-    FOREACH_LLIST(node, buckets)
-    {
+    FOREACH_LLIST (node, buckets) {
         bucket_t *bucket = container_of(node, bucket_t, this);
         if (bucket->block_size == size && bucket->free != NULL &&
             bucket->flags == flags)

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -59,7 +59,7 @@ kernel = executable(
   c_args: kernel_compile_flags,
   link_depends: [kernel_linker_script],
   link_args: [kernel_linker_flags],
-  dependencies: [libc_dep, libalgo_dep],
+  dependencies: [libc_dep, libalgo_dep, libpath_dep],
 )
 
 alias_target('kernel', kernel)

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -6,6 +6,8 @@ kernel_compile_flags = [
 
 kernel_source_files = files([
   'main.c',
+  'fs/vfs.c',
+  'fs/tar.c',
   'sys/device.c',
   'sys/sched.c',
   'sys/syscalls.c',

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -6,6 +6,7 @@ kernel_compile_flags = [
 
 kernel_source_files = files([
   'main.c',
+  'sys/device.c',
   'sys/sched.c',
   'sys/syscalls.c',
   'sys/process.c',

--- a/kernel/misc/error.c
+++ b/kernel/misc/error.c
@@ -4,9 +4,11 @@
 
 static const char *const ERROR_DESCRIPTIONS[E_TOTAL_COUNT] = {
     [E_SUCCESS] = "Success",
+    [E_NOENT] = "No such file or directory",
     [E_NOMEM] = "Out of memory",
     [E_INVAL] = "Invalid argument",
     [E_NOT_IMPLEMENTED] = "Not implemented",
+    [E_NOT_SUPPORTED] = "Operation not supported",
 };
 
 const char *err_to_str(error_t err)

--- a/kernel/sys/device.c
+++ b/kernel/sys/device.c
@@ -1,0 +1,43 @@
+#include <kernel/device.h>
+#include <kernel/kmalloc.h>
+
+#include <string.h>
+
+static error_t device_read(const dev_t *dev, char *buffer, size_t offset,
+                           size_t size)
+{
+    if (offset + size > dev->size)
+        return -E_INVAL;
+
+    memcpy(buffer, (void *)dev->start + offset, size);
+    return E_SUCCESS;
+}
+
+static error_t device_write(const dev_t *dev, size_t offset, const char *buffer,
+                            size_t size)
+{
+    if (offset + size > dev->size)
+        return -E_INVAL;
+
+    memcpy((void *)dev->start + offset, buffer, size);
+    return E_SUCCESS;
+}
+
+dev_t *device_new(u32 start, size_t size)
+{
+    dev_t *dev = kcalloc(1, sizeof(dev_t), KMALLOC_KERNEL);
+    if (dev == NULL)
+        return PTR_ERR(E_NOT_IMPLEMENTED);
+
+    *dev = (dev_t){
+        .start = start,
+        .size = size,
+        .operations =
+            {
+                .read = device_read,
+                .write = device_write,
+            },
+    };
+
+    return dev;
+}

--- a/lib/libalgo/include/libalgo/linked_list.h
+++ b/lib/libalgo/include/libalgo/linked_list.h
@@ -52,6 +52,11 @@ typedef node_t *llist_t;
 #define FOREACH_REVERSE_LLIST(_name, _head) \
     for (node_t *_name = (_tail); _name; _name = _name->prev)
 
+static ALWAYS_INLINE bool llist_is_empty(llist_t list)
+{
+    return list == NULL;
+}
+
 static inline void __llist_add(node_t **node, node_t *prev, node_t *new)
 {
     new->next = *node;

--- a/lib/libalgo/include/libalgo/linked_list.h
+++ b/lib/libalgo/include/libalgo/linked_list.h
@@ -15,6 +15,8 @@
  * @{
  */
 
+#include <kernel/types.h>
+
 #include <utils/compiler.h>
 
 #include <stddef.h>
@@ -138,8 +140,7 @@ static inline const node_t *llist_tail(llist_t head)
 
 /** Insert a new item inside a sorted list in asending order */
 static inline void llist_insert_sorted(llist_t *head, node_t *new,
-                                       int (*compare)(const node_t *,
-                                                      const node_t *))
+                                       compare_t compare)
 {
     node_t *prev = NULL;
 

--- a/lib/libalgo/include/libalgo/queue.h
+++ b/lib/libalgo/include/libalgo/queue.h
@@ -61,3 +61,18 @@ static ALWAYS_INLINE const node_t *queue_peek(const queue_t *queue)
 {
     return queue->head;
 }
+
+static inline void queue_enqueue_all(queue_t *queue, llist_t elements)
+{
+    if (llist_is_empty(elements))
+        return;
+
+    if (queue_is_empty(queue))
+        queue->head = elements;
+    else {
+        queue->tail->next = elements;
+        elements->prev = queue->tail;
+    }
+
+    queue->tail = (node_t *)llist_tail(elements);
+}

--- a/lib/libalgo/include/libalgo/tree.h
+++ b/lib/libalgo/include/libalgo/tree.h
@@ -77,4 +77,11 @@ tree_node_t *tree_remove(tree_node_t *node);
  */
 tree_node_t *tree_find_child(tree_node_t *node, compare_t, const void *data);
 
+/** Free all the elements contained inside a tree
+ *
+ *  @param root The root of the tree
+ *  @param free The function used to free an element
+ */
+void tree_free(tree_t root, void (*free_function)(tree_node_t *));
+
 /** @} */

--- a/lib/libalgo/include/libalgo/tree.h
+++ b/lib/libalgo/include/libalgo/tree.h
@@ -1,0 +1,80 @@
+/**
+ * @defgroup libalgo_tree Tree
+ * @ingroup libalgo
+ *
+ * # Tree
+ *
+ * This is our implementation of an intrusive generic tree structure.
+ *
+ * @{
+ */
+
+#pragma once
+
+#include <kernel/types.h>
+
+#include <libalgo/linked_list.h>
+#include <utils/compiler.h>
+
+/** @struct tree_node
+ *  @brief A single node inside a tree
+ */
+typedef struct tree_node {
+    node_t this; ///< Linked list node used to link children together
+    struct tree_node *parent; ///< Parent node
+    llist_t children;         ///< Linked list of children of this node
+} tree_node_t;
+
+/** The root of a tree structure */
+typedef tree_node_t *tree_t;
+
+/** Loop over each children of a tree node
+ *  @param _iter The name of the iterator used inside the loop
+ *  @param _node The tree node
+ */
+#define FOREACH_CHILDREN(_iter, _node) FOREACH_LLIST (_iter, (_node)->children)
+
+/** Convert a linked list node to its containing tree node
+ *
+ * Children of a node are linked together and addressed using a likned list, it
+ * is necessary (and trivial) to perform this conversion when iterating over
+ * them.
+ */
+static ALWAYS_INLINE tree_node_t *tree_node(node_t *node)
+{
+    return (tree_node_t *)node;
+}
+
+/** Add the given node as a children of another
+ *
+ *  @note This function appends the new child to the current list of children.
+ *        If you want to keep the children sorted use \ref tree_add_child_sorted
+ */
+void tree_add_child(tree_node_t *node, tree_node_t *child);
+
+/** Add the given node as a children of another in a sorted manner
+ *
+ * @warning This function assumes that the node's children are already sorted
+ *
+ * @param node The parent node
+ * @param child The new child
+ * @param compare The compare function used on the children
+ */
+void tree_add_child_sorted(tree_node_t *node, tree_node_t *child, compare_t);
+
+/** Remove a node from its containing tree (if any).
+ *  @return The removed node
+ */
+tree_node_t *tree_remove(tree_node_t *node);
+
+/** Find a specific child of a node
+ *
+ *  @param node The parent node
+ *  @param compare The compare function used to find the node
+ *  @param data Data passed to the compare function
+ *
+ *  @return The child or \c NULL
+ */
+tree_node_t *tree_find_child(tree_node_t *node, compare_t, const void *data);
+
+/** @} */

--- a/lib/libalgo/meson.build
+++ b/lib/libalgo/meson.build
@@ -3,6 +3,7 @@ kernel_headers = include_directories('../../include')
 
 sources = [
   'src/tree/avl.c',
+  'src/tree/tree.c',
 ]
 
 libalgo = library('libalgo', sources,

--- a/lib/libalgo/src/tree/tree.c
+++ b/lib/libalgo/src/tree/tree.c
@@ -1,3 +1,4 @@
+#include <libalgo/queue.h>
 #include <libalgo/tree.h>
 
 void tree_add_child(tree_node_t *node, tree_node_t *child)
@@ -33,4 +34,17 @@ tree_node_t *tree_find_child(tree_node_t *node, compare_t compare,
     }
 
     return NULL;
+}
+
+void tree_free(tree_t root, void (*free_function)(tree_node_t *))
+{
+    DECLARE_QUEUE(nodes);
+
+    queue_enqueue(&nodes, &root->this);
+
+    while (!queue_is_empty(&nodes)) {
+        tree_node_t *node = tree_node(queue_dequeue(&nodes));
+        queue_enqueue_all(&nodes, node->children);
+        free_function(node);
+    }
 }

--- a/lib/libalgo/src/tree/tree.c
+++ b/lib/libalgo/src/tree/tree.c
@@ -1,0 +1,36 @@
+#include <libalgo/tree.h>
+
+void tree_add_child(tree_node_t *node, tree_node_t *child)
+{
+    llist_add_tail(&node->children, &child->this);
+    child->parent = node;
+}
+
+void tree_add_child_sorted(tree_node_t *node, tree_node_t *child,
+                           compare_t compare)
+{
+    llist_insert_sorted(&node->children, &child->this, compare);
+    child->parent = node;
+}
+
+tree_node_t *tree_remove(tree_node_t *node)
+{
+    if (node->parent == NULL)
+        return node;
+
+    llist_remove(&node->parent->children, &node->this);
+    node->parent = NULL;
+
+    return node;
+}
+
+tree_node_t *tree_find_child(tree_node_t *node, compare_t compare,
+                             const void *data)
+{
+    FOREACH_CHILDREN (child, node) {
+        if (!compare(child, data))
+            return tree_node(child);
+    }
+
+    return NULL;
+}

--- a/lib/libc/include/string.h
+++ b/lib/libc/include/string.h
@@ -8,7 +8,9 @@ size_t strlen(const char *s);
 char *strncpy(char *dst, const char *src, size_t);
 
 void *memset(void *s, int c, size_t n);
-
 void *memcpy(void *restrict dest, const void *restrict src, size_t n);
+
+int strcmp(const char *, const char *);
+int strncmp(const char *, const char *, size_t);
 
 #endif /* STRING_H */

--- a/lib/libc/src/string.c
+++ b/lib/libc/src/string.c
@@ -21,3 +21,37 @@ char *strncpy(char *dst, const char *src, size_t n)
 
     return dst;
 }
+
+int strcmp(const char *s1, const char *s2)
+{
+    for (; *s1 && *s2; s1++, s2++) {
+        if (*s1 == *s2)
+            continue;
+        return *s1 - *s2;
+    }
+
+    if (*s1)
+        return 1;
+    if (*s2)
+        return -1;
+
+    return 0;
+}
+
+int strncmp(const char *s1, const char *s2, size_t count)
+{
+    for (; count > 0 && *s1 && *s2; s1++, s2++, count--) {
+        if (*s1 == *s2)
+            continue;
+        return *s1 - *s2;
+    }
+
+    if (count > 0) {
+        if (*s1)
+            return 1;
+        if (*s2)
+            return -1;
+    }
+
+    return 0;
+}

--- a/lib/libpath/include/lib/path.h
+++ b/lib/libpath/include/lib/path.h
@@ -27,6 +27,8 @@
 #ifndef LIB_LIBPATH_H
 #define LIB_LIBPATH_H
 
+#include <kernel/types.h>
+
 #include <utils/compiler.h>
 
 #include <stdbool.h>
@@ -66,6 +68,20 @@ static inline bool path_is_empty(const path_t *path)
 {
     return path->len == 0 || (path_is_absolute(path) && path->len == 1);
 }
+
+/** Store the raw path of path's parent inside a string.
+ *
+ *  The string must be allocated beforehand, and be large enough to
+ *  store the parent's raw path (including the NULL terminator).
+ *
+ *  @param parent The string inside which the parent's path is stored
+ *  @param path The original path
+ *  @param size The size of the \c parent buffer
+ *
+ *  @return The length of the parent path, -1 if the buffer wasn't large
+ *          enough or if the path is empty.
+ */
+ssize_t path_load_parent(char *parent, const path_t *path, size_t size);
 
 /**
  * @defgroup libpath_walk Path walking

--- a/lib/libpath/include/lib/path.h
+++ b/lib/libpath/include/lib/path.h
@@ -1,0 +1,197 @@
+/**
+ * @file libpath.h
+ * @brief Path processing library
+ *
+ * @author Léo DUBOIN <leo@duboin.com>
+ *
+ * @defgroup libpath Libpath
+ * @brief Path handling library
+ *
+ * # Libpath
+ *
+ * ## Description
+ *
+ * This library allows us to parse and walk along a path (backward and forward).
+ * It does so by splitting a path into different \c segments, around the '/'
+ * separator. Once a segment has been parsed, you can retrieve the previous and
+ * next ones, thus effectively walking along the original path
+ * (see \ref libpath_walk for more details).
+ *
+ * @note This library does **not** create a path nor modify the original string,
+ * and simply uses a safer simple string wrapper as well as substrings to find
+ * its way around the original raw string.
+ *
+ * @{
+ */
+
+#ifndef LIB_LIBPATH_H
+#define LIB_LIBPATH_H
+
+#include <utils/compiler.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/** Path separator. Anything else is considered as a regular character. */
+#define LIBPATH_SEPARATOR '/'
+
+/** @struct libpath_path
+ *  @brief Safer wrapper around a string symbolizing a path
+ */
+typedef struct libpath_path {
+    const char *path; ///< Original raw string containing the full path
+    size_t len;       ///< The length of the raw string
+} path_t;
+
+/** Initialize a new path */
+#define NEW_PATH(_path, _len)          \
+    (path_t)                           \
+    {                                  \
+        .path = (_path), .len = (_len) \
+    }
+
+/** Dynamically create a path using libc's \c strlen function
+ *  If you already know the string's length, use \ref NEW_PATH instead.
+ */
+#define NEW_DYNAMIC_PATH(_path) NEW_PATH((_path), strlen((_path)))
+
+/** Check whether a path is an absolute one */
+static inline bool path_is_absolute(const path_t *path)
+{
+    return path->len > 0 && path->path[0] == LIBPATH_SEPARATOR;
+}
+
+/** Check whether a path is empty */
+static inline bool path_is_empty(const path_t *path)
+{
+    return path->len == 0 || (path_is_absolute(path) && path->len == 1);
+}
+
+/**
+ * @defgroup libpath_walk Path walking
+ * @brief Walking along a path
+ *
+ * ## How to use
+ *
+ * 1. Find the first/last segment of the path (path_walk_first/path_walk_last)
+ * 2. Walk forward/backward (path_walk_next/path_walk_prev)
+ *
+ * @{
+ */
+
+/** @struct libpath_segment
+ *  @brief A single path component
+ *
+ * A path is split into multiple components (segments). For example, the
+ * absolute path '/usr/bin/env' is split into 3 separate segments:
+ * 'usr', 'bin' and 'env'
+ *
+ * This structure is used to walk along a path (forward or backward)
+ */
+typedef struct libpath_segment {
+    const char *start;  ///< Start of the segment
+    const char *end;    ///< End of the segment
+    const path_t *path; ///< The original path the segment is a part of
+
+    /// Start of the next segment.
+    /// If this segment is the last one of the path, this is set to NULL.
+    const char *next;
+
+    /// Start of the previous segment.
+    /// If this segment is the first one of the path, this is set to NULL.
+    const char *prev;
+} path_segment_t;
+
+/** Loop over all the segments of a given path.
+ *
+ *  @param _segment Name of the iterator used by the loop to store the segment
+ *  @param _path The original path
+ *  @param _body The body placed inside the loop
+ */
+#define DO_FOREACH_SEGMENT(_segment, _path, _body)   \
+    do {                                             \
+        path_segment_t _segment;                     \
+        if (path_walk_first((_path), &(_segment))) { \
+            do {                                     \
+                _body;                               \
+            } while (path_walk_next(&(_segment)));   \
+        }                                            \
+    } while (0)
+
+/** Check whether a segment is the first of ots containing path */
+static ALWAYS_INLINE bool path_segment_is_first(const path_segment_t *segment)
+{
+    return segment->prev == NULL;
+}
+
+/** Check whether a segment is the first of ots containing path */
+static ALWAYS_INLINE bool path_segment_is_last(const path_segment_t *segment)
+{
+    return segment->next == NULL;
+}
+
+/** Retieve the length of a segment's content */
+static ALWAYS_INLINE size_t path_segment_length(const path_segment_t *segment)
+{
+    if (segment->end == NULL) {
+        // If this is the last segment of a path not terminated by a separator
+        // We need to compute the length based on the original full path length
+        return (segment->path->len - (segment->start - segment->path->path));
+    }
+
+    return segment->end - segment->start;
+}
+
+/** Retrieve the first segment of a path
+ *
+ * This function returns the first segment of the path.
+ *
+ * @param path The path to walk along
+ * @param[out] segment Pointer to a struct which the segment will be stored into
+ *
+ * @return \c false if no segment could be extracted, \c true otherwise
+ */
+bool path_walk_first(const path_t *, path_segment_t *);
+
+/** Retrieve the last segment of a path
+ *
+ * This function returns the last segment of the path.
+ *
+ * @param path The path to walk along
+ * @param[out] segment Pointer to a struct which the segment will be stored into
+ *
+ * @return \c false if no segment could be extracted, \c true otherwise
+ */
+bool path_walk_last(const path_t *, path_segment_t *);
+
+/**
+ * @brief Retrieve the next segment
+ *
+ * @warning The current content inside the segment's struct will be overriden
+ *          with the information concerning the new segment.
+ *
+ * @param segment The current segment's information struct
+ *
+ * @return \c false if there is no next segment, \c true otherwise
+ */
+bool path_walk_next(path_segment_t *segment);
+
+/** Retrieve the previous segment
+ *
+ * @warning The current content inside the segment's struct will be overriden
+ *          with the information concerning the new segment.
+ *
+ * @param segment The current @ref segment's information struct
+ *
+ * @return \c false if there is no previous segment, \c true otherwise
+ */
+bool path_walk_prev(path_segment_t *segment);
+
+/** @return \c true if the segment name corresponds to the string */
+bool path_segment_is(const char *, path_segment_t *);
+
+/** @} */
+
+/** @} */
+
+#endif /* LIB_LIBPATH_H */

--- a/lib/libpath/meson.build
+++ b/lib/libpath/meson.build
@@ -1,0 +1,25 @@
+public_headers = include_directories('include')
+kernel_headers = include_directories('../../include')
+
+sources = [
+  'src/path.c',
+]
+
+libpath = library('libpath', sources,
+  include_directories : [public_headers, kernel_headers],
+  gnu_symbol_visibility : 'hidden',
+)
+
+libpath_native = library('libpath_native', sources,
+  include_directories : [public_headers, kernel_headers],
+  gnu_symbol_visibility : 'hidden',
+  native: true,
+)
+
+# Make this library usable as a Meson subproject.
+libpath_dep = declare_dependency(
+  include_directories: public_headers,
+  link_with: libpath
+)
+
+subdir('tests')

--- a/lib/libpath/src/path.c
+++ b/lib/libpath/src/path.c
@@ -172,3 +172,34 @@ bool path_segment_is(const char *name, path_segment_t *segment)
     size_t len = path_segment_length(segment);
     return strncmp(name, segment->start, len) == 0 && name[len] == '\0';
 }
+
+ssize_t path_load_parent(char *parent, const path_t *path, size_t size)
+{
+    path_segment_t segment;
+    size_t parent_length;
+
+    if (size == 0 || parent == NULL)
+        return -1;
+
+    if (!path_walk_last(path, &segment))
+        return -1;
+
+    if (path_segment_is_first(&segment)) {
+        if (!path_is_absolute(path)) {
+            parent[0] = '\0';
+            return 0;
+        }
+        parent_length = 1;
+    } else {
+        path_walk_prev(&segment);
+        parent_length = segment.end - path->path;
+    }
+
+    if (parent_length >= size)
+        return -1;
+
+    memcpy(parent, path->path, parent_length);
+    parent[parent_length] = '\0';
+
+    return parent_length;
+}

--- a/lib/libpath/src/path.c
+++ b/lib/libpath/src/path.c
@@ -1,0 +1,174 @@
+#include <lib/path.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/** Find the first character matching a predicate inside a string */
+static const char *find_first(const char *s, bool (*predicate)(char))
+{
+    if (s == NULL)
+        return NULL;
+    while (*s && !predicate(*s))
+        s += 1;
+    return *s ? s : NULL;
+}
+
+/** Find the first char inside a string matching a predicate in reverse order
+ *
+ * @param start The start of the string to look into
+ * @param end The end of the string to look into
+ */
+static const char *find_first_reverse(const char *start, const char *end,
+                                      bool (*predicate)(char))
+{
+    if (start == NULL || end == NULL)
+        return NULL;
+
+    // Start looking from the last character
+    end -= 1;
+    while (start <= end && !predicate(*end))
+        end -= 1;
+
+    return (start <= end) ? end : NULL;
+}
+
+/** Checks for a path separator */
+static inline bool issep(char c)
+{
+    return c == LIBPATH_SEPARATOR;
+}
+
+/** Negative check for a path separator */
+static inline bool isnotsep(char c)
+{
+    return !issep(c);
+}
+
+/** Parse a segment's content
+ *
+ * This function only delimits the segment's name (start, end/next)
+ * when trying to walk forward in a path. You still must manually set the \c
+ * prev and \c path field yourself.
+ *
+ * This cannot be used when trying to walk backwards in a path.
+ *
+ * @param start The start of the segment's string
+ */
+static path_segment_t path_segment_parse(const char *start)
+{
+    path_segment_t segment = {
+        // in case the segment begins with separators skip them (walk_first)
+        .start = find_first(start, isnotsep),
+    };
+
+    segment.end = find_first(segment.start, issep);
+    segment.next = find_first(segment.end, isnotsep);
+
+    return segment;
+}
+
+static path_segment_t *path_segment_parse_prev(path_segment_t *prev)
+{
+    // If there are characters before the new segments, there *might* be another
+    // segment before => we need to find the start of this previous segment
+
+    if (prev->start == prev->path->path) {
+        return prev;
+    }
+
+    // We skip the separators before the new segment.
+    const char *end_prev =
+        find_first_reverse(prev->path->path, prev->start, isnotsep) + 1;
+    // Then we skip the previous segment's content
+    prev->prev = find_first_reverse(prev->path->path, end_prev, issep);
+
+    // If NULL && path is *relative*, this means that the previous block is
+    // necessarily the first one (no separator at the start).
+    if (prev->prev == NULL && !path_is_absolute(prev->path)) {
+        prev->prev = prev->path->path;
+    } else if (prev->prev != NULL) {
+        // prev->prev is set to point to the separator otherwise
+        prev->prev += 1;
+    }
+
+    return prev;
+}
+
+bool path_walk_first(const path_t *path, path_segment_t *segment)
+{
+    if (path_is_empty(path))
+        return false;
+
+    *segment = path_segment_parse(path->path);
+    segment->path = path;
+
+    return path_segment_length(segment) > 0;
+}
+
+bool path_walk_last(const path_t *path, path_segment_t *segment)
+{
+    if (path_is_empty(path))
+        return false;
+
+    // Find the last separator inside the complete path
+    // Skip ending separators (e.g. '/usr/bin/bash/' => 'bash')
+    const char *end =
+        find_first_reverse(path->path, path->path + path->len, isnotsep) + 1;
+    const char *start = find_first_reverse(path->path, end, issep);
+
+    if (start == NULL) {
+        start = path->path;
+    } else {
+        start += 1;
+    }
+
+    *segment = (path_segment_t){
+        .start = start,
+        .end = end,
+        .next = NULL,
+        .path = path,
+    };
+
+    path_segment_parse_prev(segment);
+
+    return path_segment_length(segment) > 0;
+}
+
+bool path_walk_next(path_segment_t *segment)
+{
+    if (path_segment_is_last(segment))
+        return false;
+
+    path_segment_t next = path_segment_parse(segment->next);
+
+    next.path = segment->path;
+    next.prev = segment->start;
+
+    *segment = next;
+
+    return true;
+}
+
+bool path_walk_prev(path_segment_t *segment)
+{
+    if (path_segment_is_first(segment))
+        return false;
+
+    *segment = (path_segment_t){
+        .start = segment->prev,
+        .end = find_first(segment->prev, issep),
+        .next = segment->start,
+        .path = segment->path,
+    };
+
+    path_segment_parse_prev(segment);
+
+    return true;
+}
+
+bool path_segment_is(const char *name, path_segment_t *segment)
+{
+    size_t len = path_segment_length(segment);
+    return strncmp(name, segment->start, len) == 0 && name[len] == '\0';
+}

--- a/lib/libpath/tests/meson.build
+++ b/lib/libpath/tests/meson.build
@@ -1,0 +1,12 @@
+libpath_native_dep = declare_dependency(
+  include_directories: public_headers,
+  link_with: libpath_native
+)
+
+path_test = executable('libpath_test', 'path.c',
+  dependencies: [libpath_native_dep, test_dep],
+  include_directories: kernel_headers,
+  native: true,
+)
+
+test('path', path_test, args: [ '--color=always' ], suite: 'libpath')

--- a/lib/libpath/tests/path.c
+++ b/lib/libpath/tests/path.c
@@ -1,0 +1,118 @@
+#include <lib/path.h>
+#include <utils/macro.h>
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct path_test_params {
+    const char *path;
+    const char **components;
+    const size_t count;
+};
+
+static void libpath_test(struct path_test_params params)
+{
+    path_segment_t segment;
+    path_t path = {.path = params.path, .len = strlen(params.path)};
+
+    if (params.count == 0) {
+        cr_assert_not(path_walk_first(&path, &segment));
+        cr_assert_not(path_walk_last(&path, &segment));
+        return;
+    }
+
+    cr_assert(path_walk_first(&path, &segment));
+    cr_assert_not(path_walk_prev(&segment),
+                  "Should not be able to walk before the first segment");
+
+    for (size_t i = 0; i < params.count; ++i) {
+        cr_assert(path_segment_is(params.components[i], &segment));
+        if (i == params.count - 1)
+            cr_assert_not(path_walk_next(&segment));
+        else
+            cr_assert(path_walk_next(&segment));
+    }
+
+    for (size_t i = params.count; i > 0; --i) {
+        cr_assert(path_segment_is(params.components[i - 1], &segment));
+        if (i == 1)
+            cr_assert_not(path_walk_prev(&segment));
+        else
+            cr_assert(path_walk_prev(&segment));
+    }
+
+    cr_assert(path_walk_last(&path, &segment));
+    cr_assert_not(path_walk_next(&segment),
+                  "Should not be able to walk past the last segment");
+
+    for (size_t i = params.count; i > 0; --i) {
+        cr_assert(path_segment_is(params.components[i - 1], &segment));
+        if (i == 1)
+            cr_assert_not(path_walk_prev(&segment));
+        else
+            cr_assert(path_walk_prev(&segment));
+    }
+
+    for (size_t i = 0; i < params.count; ++i) {
+        cr_assert(path_segment_is(params.components[i], &segment));
+        if (i == params.count - 1)
+            cr_assert_not(path_walk_next(&segment));
+        else
+            cr_assert(path_walk_next(&segment));
+    }
+}
+
+#define PATH_TEST(_test_suite, _test_name, _path, ...) \
+    Test(_test_suite, _test_name)                      \
+    {                                                  \
+        const char *components[] = {__VA_ARGS__};      \
+        struct path_test_params params = {             \
+            .path = _path,                             \
+            .components = components,                  \
+            .count = ARRAY_SIZE(components),           \
+        };                                             \
+                                                       \
+        libpath_test(params);                          \
+    }
+
+Test(Path, Empty)
+{
+    struct path_test_params params = {
+        .path = "",
+        .components = NULL,
+        .count = 0,
+    };
+
+    libpath_test(params);
+}
+
+Test(Path, Root)
+{
+    struct path_test_params params = {
+        .path = "/",
+        .components = NULL,
+        .count = 0,
+    };
+
+    libpath_test(params);
+}
+
+// clang-format off
+
+PATH_TEST(Absolute, SingleComponent, "/etc", "etc")
+PATH_TEST(Absolute, MultipleComponents, "/etc/fstab", "etc", "fstab")
+PATH_TEST(Absolute, EmptyComponents, "/etc//usr////bin/sh", "etc", "usr", "bin", "sh")
+PATH_TEST(Absolute, Directory, "/etc/ssl/", "etc", "ssl")
+PATH_TEST(Absolute, DirectoryEmptyComponent, "/etc/ssl///", "etc", "ssl")
+
+PATH_TEST(Relative, SingleComponent, "etc", "etc")
+PATH_TEST(Relative, MultipleComponents, "etc/fstab", "etc", "fstab")
+PATH_TEST(Relative, EmptyComponents, "etc//usr////bin/sh", "etc", "usr", "bin", "sh")
+PATH_TEST(Relative, Directory, "etc/ssl/", "etc", "ssl")
+PATH_TEST(Relative, DirectoryEmptyComponent, "etc/ssl///", "etc", "ssl")
+PATH_TEST(Relative, SpecialCharacters, "../../../kernel/./main.c", "..", "..", "..", "kernel", ".", "main.c")

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ endif
 subdir('lib/libtest')
 subdir('lib/libc')
 subdir('lib/libalgo')
+subdir('lib/libpath')
 subdir('kernel')
 
 iso = custom_target('iso',

--- a/scripts/generate_iso.sh
+++ b/scripts/generate_iso.sh
@@ -32,12 +32,17 @@ function generate_iso()
     # Create a minimal boot partition for grub to be able to generate an iso file
     mkdir -p "$iso_dir/boot/grub"
     cp "$KERNEL_BIN" "$iso_dir/boot/$(basename "$KERNEL_BIN")"
+    touch "$iso_dir/boot/initramfs.tar" # In case it is not present, at least have an empty initramfs
+    if [ -f "$SCRIPT_DIR/../initramfs.tar" ]; then
+        cp "$SCRIPT_DIR/../initramfs.tar"  "$iso_dir/boot/initramfs.tar"
+    fi
 
     # Add a custom multiboot entry for grub to be able to boot our kernel
     cat <<EOF > "$iso_dir/boot/grub/grub.cfg"
 set timeout=0
 menuentry "Kernel - ${KERNEL_BIN%.*}" {
     multiboot /boot/$(basename "$KERNEL_BIN")
+    module /boot/initramfs.tar
 }
 EOF
 


### PR DESCRIPTION
# Virtual Filesystem

The virtual is an abstraction over filesystems used to separate the high level interface from the low level fs-dependent implementation. It also allows for computing a path which spans over multiple different imbricked filesystems, effectively viewing it as a single big filesystem from the user's POV.

This implementation comes with a POC in the form of a TAR filesystem, since it has the advantage of being really simple to implement and to generate assets for.

## TODO

* [x] Library
	* [x] Tree
	* [x] Path
* [x] VFS
	* [x] Mount a filesystem 
	* [x] Iterate over a filesystem's nodes
	* [x] Handle multiple filesystems seemlessly
	* [x] Add/Delete a node inside the VFS
* [x] POC
	* [x] Load an initramfs from bootloader
	* [x] Implement a TAR filesystem

## References 
* [Sun - original design](http://www.cs.fsu.edu/~awang/courses/cop5611_s2024/vnode.pdf)
* [OsDev - VFS](https://wiki.osdev.org/VFS)