### PR TITLE
feat(net: ipv4): implement ICMP protocol

### DIFF
--- a/include/kernel/net/icmp.h
+++ b/include/kernel/net/icmp.h
@@ -1,0 +1,30 @@
+#ifndef KERNEL_NET_ICMP_H
+#define KERNEL_NET_ICMP_H
+
+#include <kernel/error.h>
+#include <kernel/net.h>
+#include <kernel/socket.h>
+#include <kernel/types.h>
+
+extern struct socket_protocol_ops af_inet_icmp_ops;
+
+/** ICMP frame header format */
+struct icmp_header {
+    u8 type;
+    u8 code;
+    __be u16 checksum;
+};
+
+#define ICMP_HEADER_SIZE 4
+static_assert(sizeof(struct icmp_header) == ICMP_HEADER_SIZE);
+
+/** Content of the ICMP header's 'type' field */
+enum icmp_type {
+    ICMP_ECHO_REPLY = 0,   /* Ping reply */
+    ICMP_ECHO_REQUEST = 8, /* Ping request */
+};
+
+/** Process a newly received ICMP packet */
+error_t icmp_receive_packet(struct packet *packet);
+
+#endif /* KERNEL_NET_ICMP_H */

--- a/include/kernel/net/packet.h
+++ b/include/kernel/net/packet.h
@@ -80,6 +80,13 @@ struct packet {
 /** Create a new packet */
 struct packet *packet_new(size_t packet_size);
 
+/** Clone a packet.
+ *
+ *  The packet's content as well as the current offsets will be duplicated,
+ *  so that one can use a duplicated packet just like the original one.
+ */
+struct packet *packet_clone(const struct packet *packet);
+
 /** Free a packet */
 void packet_free(struct packet *packet);
 

--- a/include/kernel/socket.h
+++ b/include/kernel/socket.h
@@ -124,6 +124,8 @@ error_t socket_domain_register(struct socket_domain *);
 
 /** */
 struct socket_protocol_ops {
+    /** Initialize per-protocol data */
+    error_t (*init)(struct socket *);
     /** Associate socket with a local address */
     error_t (*bind)(struct socket *, struct sockaddr *addr, socklen_t addrlen);
     /** Connect socket to a partner */

--- a/include/kernel/socket.h
+++ b/include/kernel/socket.h
@@ -123,9 +123,7 @@ struct socket_domain {
 error_t socket_domain_register(struct socket_domain *);
 
 /** */
-struct socket_protocol {
-    int proto;             /*!< Protocol number */
-    enum socket_type type; /*!< Protocol type */
+struct socket_protocol_ops {
     /** Associate socket with a local address */
     error_t (*bind)(struct socket *, struct sockaddr *addr, socklen_t addrlen);
     /** Connect socket to a partner */
@@ -135,6 +133,13 @@ struct socket_protocol {
     error_t (*sendmsg)(struct socket *, const struct msghdr *, int flags);
     /** Read a message received by the socket */
     error_t (*recvmsg)(struct socket *, struct msghdr *, int flags);
+};
+
+/** */
+struct socket_protocol {
+    int proto;                             /*!< Protocol number */
+    enum socket_type type;                 /*!< Protocol type */
+    const struct socket_protocol_ops *ops; /*!< Protocol operations **/
 };
 
 #endif /* KERNEL_SOCKET_H */

--- a/include/uapi/kernel/net/ip.h
+++ b/include/uapi/kernel/net/ip.h
@@ -9,6 +9,7 @@
  *  @enum ip_protocol
  */
 enum ip_protocol {
+    IPPROTO_ICMP = 1,  /*!< Internet Control Message Protocol */
     IPPROTO_TCP = 6,  /*!< TCP */
     IPPROTO_UDP = 17, /*!< UDP */
 };

--- a/kernel/build.mk
+++ b/kernel/build.mk
@@ -40,6 +40,7 @@ KERNEL_SRCS := 	\
 	net/socket.c \
 	net/ethernet.c \
 	net/ipv4.c \
+	net/icmp.c \
 	net/arp.c \
 	net/interface.c \
 	net/route.c \

--- a/kernel/fs/socket.c
+++ b/kernel/fs/socket.c
@@ -71,7 +71,7 @@ socket_bind(struct file *file, struct sockaddr *addr, socklen_t len)
     if (socket->file->vnode->type != VNODE_SOCKET)
         return E_NOT_SOCKET;
 
-    return socket->proto->bind(socket, addr, len);
+    return socket->proto->ops->bind(socket, addr, len);
 }
 
 static error_t
@@ -82,7 +82,7 @@ socket_connect(struct file *file, struct sockaddr *addr, socklen_t len)
     if (socket->file->vnode->type != VNODE_SOCKET)
         return E_NOT_SOCKET;
 
-    return socket->proto->connect(socket, addr, len);
+    return socket->proto->ops->connect(socket, addr, len);
 }
 
 /*
@@ -111,7 +111,7 @@ socket_sendmsg(struct file *file, const struct msghdr *msg, int flags)
             return E_DEST_ADDR_REQUIRED;
     }
 
-    return socket->proto->sendmsg(socket, msg, flags);
+    return socket->proto->ops->sendmsg(socket, msg, flags);
 }
 
 /*
@@ -135,7 +135,7 @@ static error_t socket_recvmsg(struct file *file, struct msghdr *msg, int flags)
     if (socket->state != SOCKET_CONNECTED && !msg->msg_name)
         return E_NOT_CONNECTED;
 
-    return socket->proto->recvmsg(socket, msg, flags);
+    return socket->proto->ops->recvmsg(socket, msg, flags);
 }
 
 static error_t socket_write(struct file *file, const char *data, size_t len)

--- a/kernel/net/icmp.c
+++ b/kernel/net/icmp.c
@@ -1,5 +1,6 @@
 #define LOG_DOMAIN "icmp"
 
+#include <kernel/kmalloc.h>
 #include <kernel/logger.h>
 #include <kernel/net/ethernet.h>
 #include <kernel/net/icmp.h>
@@ -9,6 +10,27 @@
 #include <kernel/net/route.h>
 
 #include <string.h>
+
+static u16 icmp_last_identifier = 0;
+
+DECLARE_LLIST(af_inet_icmp_sockets);
+DECLARE_SPINLOCK(af_inet_icmp_sockets_lock);
+
+struct icmp_sock {
+    u16 identifier; /** ICMP echo identifier */
+    struct net_route route;
+    node_t this;
+    struct socket *socket;
+};
+
+/***/
+struct icmp_echo_header {
+    struct icmp_header icmp;
+    __be u16 identifier;
+    __be u16 sequence;
+};
+
+#define to_isock(_isock) container_of(_isock, struct icmp_sock, this)
 
 static error_t icmp_handle_echo_request(struct packet *packet)
 {
@@ -45,6 +67,30 @@ static error_t icmp_handle_echo_request(struct packet *packet)
     return ret;
 }
 
+/** Associate reply with the socket that sent the request */
+static error_t icmp_handle_echo_reply(struct packet *packet)
+{
+    struct icmp_echo_header *icmphdr = packet_payload(packet);
+    const struct icmp_sock *isock;
+
+    if (packet_payload_size(packet) < sizeof(*icmphdr))
+        return E_INVAL;
+
+    locked_scope (&af_inet_icmp_sockets_lock) {
+        FOREACH_LLIST (node, af_inet_icmp_sockets) {
+            isock = to_isock(node);
+            if (isock->identifier > icmphdr->identifier) {
+                packet_free(packet);
+                return E_SUCCESS;
+            }
+            if (isock->identifier == icmphdr->identifier)
+                break;
+        }
+    }
+
+    return socket_enqueue_packet(isock->socket, packet);
+}
+
 error_t icmp_receive_packet(struct packet *packet)
 {
     struct icmp_header *icmphdr = packet_payload(packet);
@@ -60,6 +106,8 @@ error_t icmp_receive_packet(struct packet *packet)
     switch (icmphdr->type) {
     case ICMP_ECHO_REQUEST:
         return icmp_handle_echo_request(packet);
+    case ICMP_ECHO_REPLY:
+        return icmp_handle_echo_reply(packet);
     default:
         log_warn("unsupported packet type: %d", icmphdr->type);
         ret = E_NOT_SUPPORTED;
@@ -69,3 +117,187 @@ invalid_packet:
     packet_free(packet);
     return ret;
 }
+
+static error_t af_inet_ping_bind(struct socket *socket,
+                                 struct sockaddr *sockaddr, socklen_t len)
+{
+    struct icmp_sock *isock = socket->data;
+    struct sockaddr_in *src = (struct sockaddr_in *)sockaddr;
+    struct net_interface *iface;
+    error_t ret = E_SUCCESS;
+
+    if (sockaddr->sa_family != AF_INET)
+        return E_AF_NOT_SUPPORTED;
+
+    if (len != sizeof(struct sockaddr_in))
+        return E_INVAL;
+
+    iface = net_interface_find(src->sin_addr);
+    if (iface == NULL)
+        return E_ADDR_NOT_AVAILABLE;
+
+    isock->route.src.ip = *src;
+    isock->route.netdev = iface->netdev;
+
+    return ret;
+}
+
+static error_t af_inet_ping_connect(struct socket *socket,
+                                    struct sockaddr *sockaddr, socklen_t len)
+{
+    struct icmp_sock *isock = socket->data;
+    struct sockaddr_in *dst = (struct sockaddr_in *)sockaddr;
+    struct net_route route;
+    error_t ret = E_SUCCESS;
+
+    if (sockaddr->sa_family != AF_INET)
+        return E_AF_NOT_SUPPORTED;
+
+    if (len != sizeof(struct sockaddr_in))
+        return E_INVAL;
+
+    socket_lock(socket);
+
+    ret = net_route_compute(&route, dst);
+    if (ret)
+        goto exit_connect;
+
+    /* The source address may already have been chosen by bind() */
+    if (isock->route.src.ip.sin_family != AF_UNSPEC) {
+        route.src = isock->route.src;
+        if (route.netdev != isock->route.netdev)
+            return E_NET_UNREACHABLE;
+    }
+
+    isock->route = route;
+    socket->state = SOCKET_CONNECTED;
+
+exit_connect:
+    socket_unlock(socket);
+    return ret;
+}
+
+static error_t
+af_inet_ping_send_one(struct socket *socket, const struct iovec *iov, int flags)
+{
+    struct icmp_sock *isock = socket->data;
+    struct icmp_echo_header *icmphdr = iov->iov_base;
+    struct packet *packet;
+
+    UNUSED(flags);
+
+    if (iov->iov_len < sizeof(struct icmp_echo_header))
+        return E_INVAL;
+
+    if (icmphdr->icmp.type != ICMP_ECHO_REQUEST)
+        return E_NOT_SUPPORTED;
+
+    icmphdr->identifier = isock->identifier;
+    icmphdr->icmp.checksum = 0;
+    icmphdr->icmp.checksum = net_internet_checksum(iov->iov_base, iov->iov_len);
+
+    packet = ipv4_build_packet(&isock->route, socket->proto->proto,
+                               iov->iov_base, iov->iov_len);
+    if (IS_ERR(packet))
+        return ERR_FROM_PTR(packet);
+
+    return packet_send(packet);
+}
+
+static error_t
+af_inet_ping_sendmsg(struct socket *socket, const struct msghdr *msg, int flags)
+{
+    error_t ret = E_SUCCESS;
+
+    if (flags) {
+        not_implemented("recvmsg: flags");
+        return E_NOT_SUPPORTED;
+    }
+
+    if (msg->msg_name) {
+        not_implemented("overriding destination address in sendmsg");
+        if (msg->msg_namelen != sizeof(struct sockaddr_in))
+            return E_INVAL;
+        return E_NOT_IMPLEMENTED;
+    }
+
+    socket_lock(socket);
+
+    for (size_t i = 0; i < msg->msg_iovlen; ++i) {
+        ret = af_inet_ping_send_one(socket, &msg->msg_iov[i], flags);
+        if (ret)
+            break;
+    }
+
+    socket_unlock(socket);
+
+    return ret;
+}
+
+static error_t
+af_inet_ping_recvmsg(struct socket *socket, struct msghdr *msg, int flags)
+{
+    error_t ret = E_SUCCESS;
+    struct packet *packet;
+    struct iovec *iov;
+
+    if (flags) {
+        not_implemented("recvmsg: flags");
+        return E_NOT_SUPPORTED;
+    }
+
+    if (socket->state != SOCKET_CONNECTED) {
+        if (msg->msg_namelen != sizeof(struct sockaddr_in))
+            return E_INVAL;
+        not_implemented("overriding source address in recvmsg");
+        return E_NOT_IMPLEMENTED;
+    }
+
+    // TODO: Block until packets are received (check flags/options for NOBLOCK)
+    packet = socket_dequeue_packet(socket);
+    if (!packet)
+        return E_WOULD_BLOCK;
+
+    packet_pop(packet, NULL, packet_header_size(packet));
+
+    for (size_t i = 0; i < msg->msg_iovlen; ++i) {
+        iov = &msg->msg_iov[i];
+        if (iov->iov_len > packet_read_size(packet)) {
+            // TODO: Block until enough data
+            ret = E_WOULD_BLOCK;
+        }
+        if (packet_pop(packet, iov->iov_base, iov->iov_len) < iov->iov_len)
+            break;
+    }
+
+    packet_free(packet);
+
+    return ret;
+}
+
+static error_t af_inet_ping_init(struct socket *socket)
+{
+    struct icmp_sock *isock;
+
+    isock = kcalloc(1, sizeof(*isock), KMALLOC_KERNEL);
+    if (isock == NULL)
+        return E_NOMEM;
+
+    isock->identifier = icmp_last_identifier++;
+    isock->socket = socket;
+    socket->data = isock;
+
+    spinlock_acquire(&af_inet_icmp_sockets_lock);
+    llist_add_tail(&af_inet_icmp_sockets, &isock->this);
+    spinlock_release(&af_inet_icmp_sockets_lock);
+
+    return E_SUCCESS;
+}
+
+struct socket_protocol_ops af_inet_icmp_ops = {
+    .init = af_inet_ping_init,
+    .bind = af_inet_ping_bind,
+    .connect = af_inet_ping_connect,
+    .sendmsg = af_inet_ping_sendmsg,
+    .recvmsg = af_inet_ping_recvmsg,
+};

--- a/kernel/net/icmp.c
+++ b/kernel/net/icmp.c
@@ -1,0 +1,71 @@
+#define LOG_DOMAIN "icmp"
+
+#include <kernel/logger.h>
+#include <kernel/net/ethernet.h>
+#include <kernel/net/icmp.h>
+#include <kernel/net/interface.h>
+#include <kernel/net/ipv4.h>
+#include <kernel/net/packet.h>
+#include <kernel/net/route.h>
+
+#include <string.h>
+
+static error_t icmp_handle_echo_request(struct packet *packet)
+{
+    struct icmp_header *icmphdr = packet_payload(packet);
+    struct packet *out_packet;
+    struct net_route route;
+    error_t ret = E_SUCCESS;
+
+    /* Manually create out packet's routing table entry */
+    route.netdev = packet->netdev;
+    route.src.ip.sin_addr = packet->l3.ipv4->daddr;
+    memcpy(route.src.mac.mac_addr, packet->l2.ethernet->dst,
+           sizeof(mac_address_t));
+    memcpy(route.dst.mac.mac_addr, packet->l2.ethernet->src,
+           sizeof(mac_address_t));
+    route.dst.ip.sin_addr = packet->l3.ipv4->saddr;
+
+    /* Copy the request's content with a 'reply' type */
+    icmphdr->type = ICMP_ECHO_REPLY;
+    icmphdr->checksum = 0;
+    icmphdr->checksum = net_internet_checksum(packet_payload(packet),
+                                              packet_payload_size(packet));
+
+    out_packet = ipv4_build_packet(&route, IPPROTO_ICMP, packet_payload(packet),
+                                   packet_payload_size(packet));
+    packet_free(packet);
+
+    if (IS_ERR(out_packet))
+        return ERR_FROM_PTR(out_packet);
+
+    ret = packet_send(out_packet);
+
+    packet_free(out_packet);
+    return ret;
+}
+
+error_t icmp_receive_packet(struct packet *packet)
+{
+    struct icmp_header *icmphdr = packet_payload(packet);
+    error_t ret;
+
+    if (net_internet_checksum(packet_payload(packet),
+                              packet_payload_size(packet))) {
+        log_warn("invalid checksum");
+        ret = E_INVAL;
+        goto invalid_packet;
+    }
+
+    switch (icmphdr->type) {
+    case ICMP_ECHO_REQUEST:
+        return icmp_handle_echo_request(packet);
+    default:
+        log_warn("unsupported packet type: %d", icmphdr->type);
+        ret = E_NOT_SUPPORTED;
+    }
+
+invalid_packet:
+    packet_free(packet);
+    return ret;
+}

--- a/kernel/net/ipv4.c
+++ b/kernel/net/ipv4.c
@@ -339,13 +339,17 @@ af_inet_raw_recvmsg(struct socket *socket, struct msghdr *msg, int flags)
     return ret;
 }
 
+static const struct socket_protocol_ops af_inet_raw_ops = {
+    .bind = af_inet_raw_bind,
+    .connect = af_inet_raw_connect,
+    .sendmsg = af_inet_raw_sendmsg,
+    .recvmsg = af_inet_raw_recvmsg,
+};
+
 static const struct socket_protocol af_inet_protocols[] = {
     {
         .type = SOCK_RAW,
-        .bind = af_inet_raw_bind,
-        .connect = af_inet_raw_connect,
-        .sendmsg = af_inet_raw_sendmsg,
-        .recvmsg = af_inet_raw_recvmsg,
+        .ops = &af_inet_raw_ops,
     },
 };
 

--- a/kernel/net/packet.c
+++ b/kernel/net/packet.c
@@ -26,6 +26,28 @@ struct packet *packet_new(size_t packet_size)
     return packet;
 }
 
+struct packet *packet_clone(const struct packet *packet)
+{
+    struct packet *duplicate;
+
+    duplicate = packet_new(packet->allocated_size);
+    if (IS_ERR(duplicate))
+        return duplicate;
+
+    /* Copy packet's content */
+    packet_put(duplicate, packet_start(packet), packet_size(packet));
+
+    /* Copy state */
+    duplicate->popped = packet->popped;
+    duplicate->netdev = packet->netdev;
+
+    /* Recompute header offsets */
+    packet_set_l3_size(duplicate, packet->l3.raw - packet->l2.raw);
+    duplicate->payload = packet_start(duplicate) + packet_header_size(packet);
+
+    return duplicate;
+}
+
 void packet_free(struct packet *packet)
 {
     kfree(packet);


### PR DESCRIPTION
# Internet Control Message Protocol

Event though the ICMP v4 protocol defines a whole lot of message types, we are simply going to implement the ones that are useful to us. For this first implementation, this means echo (aka. ping) request/reply.

ICMP Query/Informational messages (including echo requests) are responded to automatically by the kernel, and should not be
transferred to any ICMP sockets.

It should be possible to send echo requests and read echo replies through regular sockets (AF_INET, SOCK_DGRAM, IPPROTO_ICMP). Only echo requests messages should be accepted when sending, and only echo replies should be
taken into account when receiving.

## TODO

- [x] Allowing copying to both RAW and ICMP (or any other protocol) sockets
- [x] Responding to echo request automatically
- [x] Bind: allocate a unique request identifier
- [x] Connect: set destination address
- [x] Sendmsg: sending ICMP echo requests only
- [x] Recvfrom: reading ICMP echo replies only

## Links

- Stevens TCP/IP protocol illustrated - Chapter 8
- [RFC0792](https://www.rfc-editor.org/rfc/rfc792.html)