### PR TITLE
fix(spinlock): reversed condition in spinlock_acquire()

### DIFF
--- a/include/kernel/sched.h
+++ b/include/kernel/sched.h
@@ -61,13 +61,16 @@
 extern bool scheduler_initialized;
 
 /**
- * @brief Reschedule the current thread
+ * Reschedule the current thread
  *
  * This is the **main** function of the scheduler. It is called when we want to
  * switch to the next scheduled thread. It automatically reinserts the current
  * thread into the correct queue depending on its state.
  */
 void schedule(void);
+
+/** Forcibly reschedule the current thread */
+void schedule_preempt(void);
 
 /** Lock the different interna synchronization mechanisms
  *  @return Wether interrupts were previously enabled

--- a/include/kernel/semaphore.h
+++ b/include/kernel/semaphore.h
@@ -22,18 +22,17 @@ typedef struct semaphore semaphore_t;
 /** Semaphore init value.
  *  @param count The number of users that can take this semaphore simultaneously
  */
-#define SEMAPHORE_INIT(_count)      \
-    ((struct semaphore){            \
-        INIT_SPINLOCK(.lock),       \
-        INIT_WAITQUEUE(.waitqueue), \
-        .count = (_count),          \
-    })
+#define SEMAPHORE_INIT(_count)     \
+    ((struct semaphore){           \
+        .count = (_count),         \
+        .lock = {.locked = false}, \
+        .waitqueue = {.lock = {.locked = false}, .queue = {NULL, NULL}}})
 
 /** Initialize a semaphore */
 #define INIT_SEMAPHORE(_name, _count) _name = SEMAPHORE_INIT(_count)
 
 /** Declare and initialize a semaphore */
-#define DECLARE_SEMAPHORE(_count) \
+#define DECLARE_SEMAPHORE(_name, _count) \
     struct semaphore _name = SEMAPHORE_INIT(_count)
 
 /** Mutex init value. */

--- a/include/kernel/spinlock.h
+++ b/include/kernel/spinlock.h
@@ -31,7 +31,7 @@ typedef struct spinlock {
 /** @brief Try to acquire a spinlock, or wait until it is free */
 static ALWAYS_INLINE spinlock_t *spinlock_acquire(spinlock_t *lock)
 {
-    WAIT_FOR(__atomic_test_and_set(&lock->locked, __ATOMIC_ACQUIRE));
+    WAIT_FOR(!__atomic_test_and_set(&lock->locked, __ATOMIC_ACQUIRE));
     return lock;
 }
 

--- a/kernel/arch/i686/process.c
+++ b/kernel/arch/i686/process.c
@@ -1,4 +1,3 @@
-#include "utils/container_of.h"
 #define LOG_DOMAIN "process"
 
 #include <kernel/error.h>
@@ -6,10 +5,12 @@
 #include <kernel/logger.h>
 #include <kernel/mmu.h>
 #include <kernel/process.h>
+#include <kernel/sched.h>
 
 #include <kernel/arch/i686/gdt.h>
 
 #include <utils/compiler.h>
+#include <utils/container_of.h>
 #include <utils/macro.h>
 
 #include <string.h>
@@ -64,6 +65,9 @@ arch_thread_jump_to_userland(thread_entry_t entrypoint, void *data)
 static void arch_thread_entrypoint(thread_entry_t entrypoint, void *data)
 {
     u32 *ustack = NULL;
+
+    /* scheduler was locked by the previous thread before starting this one */
+    scheduler_unlock(true);
 
     if (thread_is_initial(current)) {
         if (!vmm_init(current->process->vmm, USER_MEMORY_START,

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -406,6 +406,8 @@ void kernel_task_worker(void *data)
 #undef LOG_DOMAIN
 #define LOG_DOMAIN "kmutex"
 
+static DECLARE_MUTEX(mutex);
+
 static void __kernel_task_mutex(void *data)
 {
     semaphore_t *mutex = data;
@@ -426,8 +428,6 @@ void kernel_task_mutex(void *data)
     struct thread *thread_b;
 
     UNUSED(data);
-
-    DECLARE_MUTEX(mutex);
 
     thread_a = thread_spawn(&kernel_process, __kernel_task_mutex, &mutex,
                             THREAD_KERNEL);

--- a/kernel/misc/waitqueue.c
+++ b/kernel/misc/waitqueue.c
@@ -30,7 +30,7 @@ void waitqueue_enqueue_locked(struct waitqueue *queue, struct thread *thread)
     }
 
     if (thread == current)
-        schedule();
+        schedule_preempt();
 }
 
 const struct thread *waitqueue_peek(struct waitqueue *queue)


### PR DESCRIPTION
# Issue

Since the very beginning, our spinlock logic was reversed. Meaning the lock would block only when not already taken, and allow continuing when nobody else was holding it. We should obviously fix it and correct any locking errors that wasn't detected before !